### PR TITLE
Improved support for half duplex (single wire) operation of TMC2208

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -899,6 +899,9 @@ class TMC2208Stepper : public TMCStepper {
 		static constexpr uint8_t  TMC2208_SYNC = 0x05,
 															TMC2208_SLAVE_ADDR = 0x00;
 		const bool write_only;
+    #if SW_CAPABLE_PLATFORM
+    const bool full_duplex;
+    #endif
 		static constexpr uint8_t replyDelay = 5;
 };
 


### PR DESCRIPTION
With the existing code half duplex operation when using a software serial implementaion on LPC1768 boards can occasionally generate spurious temperature warnings when monitoring is enabled. This is caused by a null character sometimes being generated when the TMC2208 switches from output mode to input mode. In some circumstances (typically when interrupts delay the calls to read data in the _sendDatagram function) this extra null byte will be read as part of reading the response packet causing the entire packet to be shifted by 8 bits and resulting in a CRC error (but invalid data will stil be returned).

During testing two further issues were observed.
1) When the TX output is buffred not all of the echoed output packet will be available to be read by the for loop immeadiately after the send.
2) Occasionally the read to discard the echo of the command packet can be delayed and in half duplex mode (when there is no echo) this delayed read will consume some of the response packet.
This commit addresses all of these issues.
 1. Only 8 bytes are read when reading the response packet so the spurious null will be ignored (and discarded on the next read).
2. The reads to discard the echo data are now made after the delay for the response to be generated. This ensures time for all command data to be sent and echoed.
3. The reads to discard echo data are only made when operating in full duplex mode (they are not needed in half duplex).