### PR TITLE
Correctly handling VACTUAL 24bit signed integer

### DIFF
--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -69,7 +69,13 @@ void TMC5130Stepper::XACTUAL(int32_t input) {
 }
 ///////////////////////////////////////////////////////////////////////////////////////
 // R: VACTUAL
-int32_t TMC5130Stepper::VACTUAL() { return read(VACTUAL_t::address); }
+int32_t TMC5130Stepper::VACTUAL() {
+  uint32_t int24 = read(VACTUAL_t::address);
+  if(bitRead(int24, 23)) {
+    int24 |= 0xFF000000;
+  }
+  return int24;
+}
 ///////////////////////////////////////////////////////////////////////////////////////
 // W: VSTART
 uint32_t TMC5130Stepper::VSTART() { return VSTART_register.sr; }

--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -71,7 +71,7 @@ void TMC5130Stepper::XACTUAL(int32_t input) {
 // R: VACTUAL
 int32_t TMC5130Stepper::VACTUAL() {
   uint32_t int24 = read(VACTUAL_t::address);
-  if((int24 >> 23) & 0x01) { {
+  if((int24 >> 23) & 0x01) {
     int24 |= 0xFF000000;
   }
   return int24;

--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -71,7 +71,7 @@ void TMC5130Stepper::XACTUAL(int32_t input) {
 // R: VACTUAL
 int32_t TMC5130Stepper::VACTUAL() {
   uint32_t int24 = read(VACTUAL_t::address);
-  if(bitRead(int24, 23)) {
+  if((int24 >> 23) & 0x01) { {
     int24 |= 0xFF000000;
   }
   return int24;


### PR DESCRIPTION
Negative readings of the signed 24 bit register VACTUAL resulted in wrong numbers because it didn't convert to 32 bit properly. The 24th sign bit needs to be "extended" to the unused 4th byte, which is why I'm ORing it with 0xFF000000 if the 24th bit is set (signifying a negative integer).
The same is most likely also true for PWM_SCALE_AUTO, a 9 bit signed int, but I haven't had the time to look into it.