### PR TITLE
add tmc2209 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Supported TMC drivers:
 * TMC5130
 * TMC5160
 * TMC5161
+* TMC2209

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
 	"name": "TMCStepper",
-	"version": "0.3.5",
-	"keywords": "TMC, Trinamic, stepper, driver, SPI, UART, TMC2130, TMC2160, TMC2208, TMC2224, TMC2660, TMC5130, TMC5160, TMC5161",
+	"version": "0.3.6",
+	"keywords": "TMC, Trinamic, stepper, driver, SPI, UART, TMC2130, TMC2160, TMC2208, TMC2224, TMC2660, TMC5130, TMC5160, TMC5161, TMC2209",
 	"description": "Arduino library for configuring Trinamic stepper drivers.",
 	"repository":
 	{

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TMCStepper
-version=0.3.5
+version=0.3.6
 author=teemuatlut
 maintainer=teemuatlut
 sentence=Arduino library for Trinamic stepper drivers

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -20,6 +20,7 @@
 #include "source/TMC5160_bitfields.h"
 #include "source/TMC2208_bitfields.h"
 #include "source/TMC2660_bitfields.h"
+#include "source/TMC2209_bitfields.h"
 
 #define INIT_REGISTER(REG) REG##_t REG##_register = REG##_t
 #define INIT2130_REGISTER(REG) TMC2130_n::REG##_t REG##_register = TMC2130_n::REG##_t
@@ -28,10 +29,11 @@
 #define INIT5160_REGISTER(REG) TMC5160_n::REG##_t REG##_register = TMC5160_n::REG##_t
 #define INIT2660_REGISTER(REG) TMC2660_n::REG##_t REG##_register = TMC2660_n::REG##_t
 #define INIT2208_REGISTER(REG) TMC2208_n::REG##_t REG##_register = TMC2208_n::REG##_t
+#define INIT2209_REGISTER(REG) TMC2209_n::REG##_t REG##_register = TMC2209_n::REG##_t
 #define INIT2224_REGISTER(REG) TMC2224_n::REG##_t REG##_register = TMC2224_n::REG##_t
 #define SET_ALIAS(TYPE, DRIVER, NEW, ARG, OLD) TYPE (DRIVER::*NEW)(ARG) = &DRIVER::OLD
 
-#define TMCSTEPPER_VERSION 0x000305 // v0.3.5
+#define TMCSTEPPER_VERSION 0x000306 // v0.3.6
 
 class TMCStepper {
 	public:
@@ -1085,4 +1087,24 @@ class TMC2660Stepper {
 		uint32_t spi_speed = 16000000/8; // Default 2MHz
 		uint8_t _savedToff = 0;
 		SW_SPIClass * TMC_SW_SPI = NULL;
+};
+
+class TMC2209Stepper : public TMC2208Stepper {	
+	public:
+		//TMC2209Stepper(HardwareSerial& serial);
+		TMC2209Stepper(Stream * SerialPort, float RS, bool has_rx=true);
+		#if SW_CAPABLE_PLATFORM
+			TMC2209Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, bool has_rx=true);
+		#endif
+
+		void sgt(uint8_t  B);
+		uint8_t sgt();
+
+		// W: TCOOLTHRS
+		uint32_t TCOOLTHRS();
+		void TCOOLTHRS(uint32_t input);
+
+	protected:
+		INIT_REGISTER(SGTHRS){.sr=0};	// 32b
+		INIT2209_REGISTER(TCOOLTHRS){.sr=0};	// 32b
 };

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -1092,9 +1092,9 @@ class TMC2660Stepper {
 class TMC2209Stepper : public TMC2208Stepper {	
 	public:
 		//TMC2209Stepper(HardwareSerial& serial);
-		TMC2209Stepper(Stream * SerialPort, float RS, bool has_rx=true);
+		TMC2209Stepper(Stream * SerialPort, float RS, uint8_t slave=0x00, bool has_rx=true);
 		#if SW_CAPABLE_PLATFORM
-			TMC2209Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, bool has_rx=true);
+			TMC2209Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, uint8_t slave=0x00, bool has_rx=true);
 		#endif
 
 		void sgt(uint8_t  B);
@@ -1107,4 +1107,10 @@ class TMC2209Stepper : public TMC2208Stepper {
 	protected:
 		INIT_REGISTER(SGTHRS){.sr=0};	// 32b
 		INIT2209_REGISTER(TCOOLTHRS){.sr=0};	// 32b
+    
+		void write(uint8_t, uint32_t);
+		uint32_t read(uint8_t);
+    
+		static constexpr uint8_t  TMC2209_SYNC = 0x05;
+		uint8_t  slave_addr;
 };

--- a/src/source/TMC2209Stepper.cpp
+++ b/src/source/TMC2209Stepper.cpp
@@ -1,0 +1,23 @@
+#include "TMCStepper.h"
+#include "TMC_MACROS.h"
+
+TMC2209Stepper::TMC2209Stepper(Stream * SerialPort, float RS, bool has_rx) : TMC2208Stepper(SerialPort, RS, has_rx) {}
+#if SW_CAPABLE_PLATFORM
+TMC2209Stepper::TMC2209Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, bool has_rx) :
+			TMC2208Stepper(SW_RX_pin, SW_TX_pin, RS, has_rx){}
+#endif
+
+void TMC2209Stepper::sgt(	uint8_t  B )	{ SGTHRS_register.sr = B; write(SGTHRS_register.address, SGTHRS_register.sr);		}
+uint8_t TMC2209Stepper::sgt() {
+	// Two's complement in a 7bit value
+	uint8_t val = (SGTHRS_register.sr &  0x40) << 1; // Isolate sign bit
+	val |= SGTHRS_register.sr & 0x7F;
+	return val;
+}
+
+// W: TCOOLTHRS
+uint32_t TMC2209Stepper::TCOOLTHRS() { return TCOOLTHRS_register.sr; }
+void TMC2209Stepper::TCOOLTHRS(uint32_t input) {
+  TCOOLTHRS_register.sr = input;
+  write(TCOOLTHRS_register.address, TCOOLTHRS_register.sr);
+}

--- a/src/source/TMC2209Stepper.cpp
+++ b/src/source/TMC2209Stepper.cpp
@@ -1,11 +1,71 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC2209Stepper::TMC2209Stepper(Stream * SerialPort, float RS, bool has_rx) : TMC2208Stepper(SerialPort, RS, has_rx) {}
+TMC2209Stepper::TMC2209Stepper(Stream * SerialPort, float RS, uint8_t slave, bool has_rx) : TMC2208Stepper(SerialPort, RS, has_rx) {this->slave_addr = slave;}
 #if SW_CAPABLE_PLATFORM
-TMC2209Stepper::TMC2209Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, bool has_rx) :
-			TMC2208Stepper(SW_RX_pin, SW_TX_pin, RS, has_rx){}
+TMC2209Stepper::TMC2209Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, uint8_t slave, bool has_rx) :
+			TMC2208Stepper(SW_RX_pin, SW_TX_pin, RS, has_rx){this->slave_addr = slave;}
 #endif
+
+void TMC2209Stepper::write(uint8_t addr, uint32_t regVal) {
+	uint8_t len = 7;
+	addr |= TMC_WRITE;
+	uint8_t datagram[] = {TMC2209_SYNC, this->slave_addr, addr, (uint8_t)(regVal>>24), (uint8_t)(regVal>>16), (uint8_t)(regVal>>8), (uint8_t)(regVal>>0), 0x00};
+
+	datagram[len] = calcCRC(datagram, len);
+
+	#if SW_CAPABLE_PLATFORM
+		if (SWSerial != NULL) {
+				for(int i=0; i<=len; i++){
+					bytesWritten += SWSerial->write(datagram[i]);
+				}
+		} else
+	#endif
+		{
+			for(int i=0; i<=len; i++){
+				bytesWritten += HWSerial->write(datagram[i]);
+		}
+	}
+	delay(replyDelay);
+}
+
+template<typename SERIAL_TYPE>
+extern uint64_t _sendDatagram(SERIAL_TYPE &serPtr, uint8_t datagram[], const uint8_t len, uint16_t timeout);
+
+uint32_t TMC2209Stepper::read(uint8_t addr) {
+	constexpr uint8_t len = 3;
+	addr |= TMC_READ;
+	uint8_t datagram[] = {TMC2209_SYNC, this->slave_addr, addr, 0x00};
+	datagram[len] = calcCRC(datagram, len);
+	uint64_t out = 0x00000000UL;
+
+	for (uint8_t i = 0; i < max_retries; i++) {
+		#if SW_CAPABLE_PLATFORM
+			if (SWSerial != NULL) {
+					SWSerial->listen();
+					out = _sendDatagram(*SWSerial, datagram, len, abort_window);
+					SWSerial->stopListening();
+			} else
+		#endif
+			{
+				out = _sendDatagram(*HWSerial, datagram, len, abort_window);
+			}
+
+		delay(replyDelay);
+
+		CRCerror = false;
+		uint8_t out_datagram[] = {(uint8_t)(out>>56), (uint8_t)(out>>48), (uint8_t)(out>>40), (uint8_t)(out>>32), (uint8_t)(out>>24), (uint8_t)(out>>16), (uint8_t)(out>>8), (uint8_t)(out>>0)};
+		uint8_t crc = calcCRC(out_datagram, 7);
+		if ((crc != (uint8_t)out) || crc == 0 ) {
+			CRCerror = true;
+			out = 0;
+		} else {
+			break;
+		}
+	}
+
+	return out>>8;
+}
 
 void TMC2209Stepper::sgt(	uint8_t  B )	{ SGTHRS_register.sr = B; write(SGTHRS_register.address, SGTHRS_register.sr);		}
 uint8_t TMC2209Stepper::sgt() {

--- a/src/source/TMC2209_bitfields.h
+++ b/src/source/TMC2209_bitfields.h
@@ -1,0 +1,47 @@
+#pragma once
+#pragma pack(push, 1)
+
+namespace TMC2209_n {
+  struct TCOOLTHRS_t {
+    constexpr static uint8_t address = 0x14;
+    uint32_t sr : 20;
+  };
+}
+
+struct SGTHRS_t {
+  constexpr static uint8_t address = 0x40;
+  uint8_t sr : 8;
+};
+
+struct SG_RESULT_t {
+  constexpr static uint8_t address = 0x41;
+  uint16_t sr : 10;
+};
+
+namespace TMC2209_n {
+  struct COOLCONF_t {
+    constexpr static uint8_t address = 0x42;
+    union {
+      uint16_t sr : 16;
+      struct {
+        bool  seimin : 1,
+              sedn1 : 1,
+              sedn0 : 1,
+                    : 1,
+              semax3 : 1,
+              semax2 : 1,
+              semax1 : 1,
+              semax0 : 1,
+                    : 1,
+              seup1 : 1,
+              seup0 : 1,
+                    : 1,
+              semin3 : 1,
+              semin2 : 1,
+              semin1 : 1,
+              semin0 : 1;
+      };
+    };
+  };
+};
+#pragma pack(pop)

--- a/src/source/TMC_platforms.h
+++ b/src/source/TMC_platforms.h
@@ -13,7 +13,7 @@
   #define writeMOSI_L g_APinDescription[mosi_pin].pPort -> PIO_CODR = g_APinDescription[mosi_pin].ulPin
   #define writeSCK_H g_APinDescription[sck_pin].pPort -> PIO_SODR = g_APinDescription[sck_pin].ulPin
   #define writeSCK_L g_APinDescription[sck_pin].pPort -> PIO_CODR = g_APinDescription[sck_pin].ulPin
-  #define readMISO !!(g_APinDescription[miso_pin].pPort -> PIO_PDSR & g_APinDescription[miso_pin].ulPin)
+  #define readMISO PIO_Get( g_APinDescription[miso_pin].pPort, PIO_INPUT, g_APinDescription[miso_pin].ulPin )
 #elif defined(TARGET_LPC1768) // LPC1769:2.4MHz
   typedef volatile LPC_GPIO_TypeDef* fastio_reg;
   typedef uint32_t fastio_bm;


### PR DESCRIPTION
The Library of tmc2209 is inherited from tmc2208
  1. add stallGuard detection function
  2. add slave address,  tmc2209 slave address can be set in 0x00-0x03, so 4 tmc2209 can be mounted on one UART port