### PR TITLE
Refactored DCCTRL from 2160 to 2130.

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -257,6 +257,14 @@ class TMC2130Stepper : public TMCStepper {
 		int8_t sgt();
 		bool sfilt();
 
+		// W: DCCTRL
+		void DCCTRL(uint32_t input);
+		void dc_time(uint16_t input);
+		void dc_sg(uint8_t input);
+		uint32_t DCCTRL();
+		uint16_t dc_time();
+		uint8_t dc_sg();
+
 		// R: DRV_STATUS
 		uint32_t DRV_STATUS();
 		uint16_t sg_result();
@@ -316,6 +324,7 @@ class TMC2130Stepper : public TMCStepper {
 		INIT_REGISTER(VDCMIN){.sr=0};			// 32b
 		INIT_REGISTER(CHOPCONF){{.sr=0}};	// 32b
 		INIT_REGISTER(COOLCONF){{.sr=0}};	// 32b
+		INIT_REGISTER(DCCTRL){{.sr = 0}};	// 32b
 		INIT_REGISTER(PWMCONF){{.sr=0}};	// 32b
 		INIT_REGISTER(ENCM_CTRL){{.sr=0}};//  8b
 
@@ -389,14 +398,6 @@ class TMC2160Stepper : public TMC2130Stepper {
 		// R: OFFSET_READ
 		uint16_t OFFSET_READ();
 
-		// W: DCCTRL (0x6E)
-		void DCCTRL(uint32_t input);
-		void dc_time(uint16_t input);
-		void dc_sg(uint8_t input);
-		uint32_t DCCTRL();
-		uint16_t dc_time();
-		uint8_t dc_sg();
-
 		// W: PWMCONF
 		void PWMCONF(uint32_t input);
 		void pwm_ofs(uint8_t B);
@@ -426,7 +427,6 @@ class TMC2160Stepper : public TMC2130Stepper {
 		INIT_REGISTER(DRV_CONF){{.sr=0}};
 		INIT_REGISTER(GLOBAL_SCALER){.sr=0};
 		INIT_REGISTER(OFFSET_READ){.sr=0};
-		INIT2160_REGISTER(DCCTRL){{.sr=0}};
 		INIT2160_REGISTER(PWMCONF){{.sr=0}};
 
 		static constexpr float default_RS = 0.075;

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -646,7 +646,6 @@ class TMC5130Stepper : public TMC2160Stepper {
 		INIT_REGISTER(MSLUTSTART){0};
 		INIT_REGISTER(MSCNT){0};
 		INIT_REGISTER(MSCURACT){0};
-		INIT_REGISTER(DCCTRL){0};
 		*/
 
 		static constexpr float default_RS = 0.15;

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -130,6 +130,7 @@ void TMC2130Stepper::push() {
   VDCMIN(VDCMIN_register.sr);
   CHOPCONF(CHOPCONF_register.sr);
   COOLCONF(COOLCONF_register.sr);
+  DCCTRL(DCCTRL_register.sr);
   PWMCONF(PWMCONF_register.sr);
   ENCM_CTRL(ENCM_CTRL_register.sr);
 }
@@ -178,6 +179,33 @@ uint32_t TMC2130Stepper::VDCMIN() { return VDCMIN_register.sr; }
 void TMC2130Stepper::VDCMIN(uint32_t input) {
   VDCMIN_register.sr = input;
   write(VDCMIN_register.address, VDCMIN_register.sr);
+}
+///////////////////////////////////////////////////////////////////////////////////////
+// RW: DCCTRL
+void TMC2130Stepper::DCCTRL(uint32_t input) {
+	DCCTRL_register.sr = input;
+	write(DCCTRL_register.address, DCCTRL_register.sr);
+}
+void TMC2130Stepper::dc_time(uint16_t input) {
+	DCCTRL_register.dc_time = input;
+	write(DCCTRL_register.address, DCCTRL_register.sr);
+}
+void TMC2130Stepper::dc_sg(uint8_t input) {
+	DCCTRL_register.dc_sg = input;
+	write(DCCTRL_register.address, DCCTRL_register.sr);
+}
+
+uint32_t TMC2130Stepper::DCCTRL() {
+	DCCTRL_register.sr = read(DCCTRL_register.address);
+	return DCCTRL_register.sr;
+}
+uint16_t TMC2130Stepper::dc_time() {
+	DCCTRL();
+	return DCCTRL_register.dc_time;
+}
+uint8_t TMC2130Stepper::dc_sg() {
+	DCCTRL();
+	return DCCTRL_register.dc_sg;
 }
 ///////////////////////////////////////////////////////////////////////////////////////
 // R: PWM_SCALE

--- a/src/source/TMC2130_bitfields.h
+++ b/src/source/TMC2130_bitfields.h
@@ -170,6 +170,18 @@ struct COOLCONF_t {
   };
 };
 
+struct DCCTRL_t {
+	constexpr static uint8_t address = 0x6E;
+	union {
+		uint32_t sr : 24;
+		struct {
+			uint16_t dc_time : 10,
+				: 6;
+			uint8_t dc_sg : 8;
+		};
+	};
+};
+
 namespace TMC2130_n {
   struct DRV_STATUS_t {
     constexpr static uint8_t address = 0x6F;

--- a/src/source/TMC2160Stepper.cpp
+++ b/src/source/TMC2160Stepper.cpp
@@ -100,30 +100,3 @@ void TMC2160Stepper::GLOBAL_SCALER(uint8_t input) {
 
 // R: OFFSET_READ
 uint16_t TMC2160Stepper::OFFSET_READ() { return read(OFFSET_READ_register.address); }
-
-// W: DCCTRL (0x6E)
-void TMC2160Stepper::DCCTRL(uint32_t input) {
-  DCCTRL_register.sr = input;
-  write(DCCTRL_register.address, DCCTRL_register.sr);
-}
-void TMC2160Stepper::dc_time(uint16_t input) {
-  DCCTRL_register.dc_time = input;
-  write(DCCTRL_register.address, DCCTRL_register.sr);
-}
-void TMC2160Stepper::dc_sg(uint8_t input) {
-  DCCTRL_register.dc_sg = input;
-  write(DCCTRL_register.address, DCCTRL_register.sr);
-}
-
-uint32_t TMC2160Stepper::DCCTRL() {
-  DCCTRL_register.sr = read(DCCTRL_register.address);
-  return DCCTRL_register.sr;
-}
-uint16_t TMC2160Stepper::dc_time() {
-  DCCTRL();
-  return DCCTRL_register.dc_time;
-}
-uint8_t TMC2160Stepper::dc_sg() {
-  DCCTRL();
-  return DCCTRL_register.dc_sg;
-}

--- a/src/source/TMC2160_bitfields.h
+++ b/src/source/TMC2160_bitfields.h
@@ -37,18 +37,6 @@ namespace TMC2160_n {
       };
     };
   };
-
-  struct DCCTRL_t {
-    constexpr static uint8_t address = 0x6E;
-    union {
-      uint32_t sr : 24;
-      struct {
-        uint16_t dc_time : 10,
-                         : 6;
-        uint8_t dc_sg : 8;
-      };
-    };
-  };
 }
 
 #pragma pack(pop)

--- a/src/source/TMC5130_bitfields.h
+++ b/src/source/TMC5130_bitfields.h
@@ -235,16 +235,4 @@ struct MSLUTSTART_t {
   };
 };
 
-struct DCCTRL_t {
-  constexpr static uint8_t address = 0x6E;
-  union {
-    uint32_t sr : 24;
-    struct {
-      uint16_t dc_time : 10,
-                       : 5;
-      uint8_t dc_sg : 8;
-    };
-  };
-};
-
 #pragma pack(pop)


### PR DESCRIPTION
I moved the DCCTRL register from 2160 to 2130 so that I could set dc_time and dc_sg while using my 2130. Also, I had to remove the 5130 ```DCCTRL_t``` bitfield struct to avoid redefinition. I assume this was left over from previous work and is no longer necessary.
To Note:

- 5130's ```DCCTRL_t.dc_time :10, :5;``` instead of 10,6 
   - _I checked the [5130 register definitions](https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC5130_datasheet.pdf) and it does match the 2130 with 6 bits of fill, so the 5 must have just been a typo._
- 5130 still has ```INIT_REGISTER(DCCTRL){0};``` commented out under class declaration
   - _I removed this now_