### PR TITLE
add libmaple STM32F1 SoftwareSerial capable define

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -10,7 +10,7 @@
 	#include <Arduino.h>
 #endif
 
-#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_ESP32)
+#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_STM32F1)
 
 #include <Stream.h>
 #include <SPI.h>


### PR DESCRIPTION
If you add this , so i can add software serial for stm32f1 boards.