### PR TITLE
Check for SW_SERIAL_PLACEHOLDER

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -21,6 +21,9 @@
 
 #if SW_CAPABLE_PLATFORM
 	#include <SoftwareSerial.h>
+  #ifdef SW_SERIAL_PLACEHOLDER
+    #undef SW_CAPABLE_PLATFORM
+  #endif
 #endif
 
 #include "source/SW_SPI.h"

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -21,9 +21,9 @@
 
 #if SW_CAPABLE_PLATFORM
 	#include <SoftwareSerial.h>
-  #ifdef SW_SERIAL_PLACEHOLDER
-    #undef SW_CAPABLE_PLATFORM
-  #endif
+	#ifdef SW_SERIAL_PLACEHOLDER
+		#undef SW_CAPABLE_PLATFORM
+	#endif
 #endif
 
 #include "source/SW_SPI.h"


### PR DESCRIPTION
A flag has been added to Marlin's dummy implementation of SoftwareSerial, so when TMCStepper is used within Marlin there will be a failsafe to prevent compilation errors in platforms that don't have a useable C++17.