### PR TITLE
Remove ESP32 from list of SW_CAPABLE_PLATFORMs

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -16,7 +16,7 @@
 #ifdef __has_include
 	#define SW_CAPABLE_PLATFORM __has_include(<SoftwareSerial.h>)
 #else
-	#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_STM32F1)
+	#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_STM32F1)
 #endif
 
 #if SW_CAPABLE_PLATFORM


### PR DESCRIPTION
since there is no default SoftwareSerial library for the ESP32

fixes #59 