### PR TITLE
Fix support for BIGTECHTREE SKR 1.3 board

### DIFF
--- a/src/source/TMC_platforms.h
+++ b/src/source/TMC_platforms.h
@@ -17,11 +17,11 @@
 #elif defined(TARGET_LPC1768) // LPC1769:2.4MHz
   //typedef volatile LPC_GPIO_TypeDef* fastio_reg;
   //typedef uint32_t fastio_bm;
-  #define writeMOSI_H gpio_set(mosi_pin)
-  #define writeMOSI_L gpio_clear(mosi_pin)
-  #define writeSCK_H gpio_set(sck_pin)
-  #define writeSCK_L gpio_clear(sck_pin)
-  #define readMISO gpio_get(miso_pin)
+  #define writeMOSI_H digitalWrite(mosi_pin, HIGH)
+  #define writeMOSI_L digitalWrite(mosi_pin, LOW)
+  #define writeSCK_H digitalWrite(sck_pin, HIGH)
+  #define writeSCK_L digitalWrite(sck_pin, LOW)
+  #define readMISO digitalRead(miso_pin)
 #else // DUE:116kHz
   #define writeMOSI_H digitalWrite(mosi_pin, HIGH)
   #define writeMOSI_L digitalWrite(mosi_pin, LOW)


### PR DESCRIPTION
I had a problem with the board not working (it's based on LPC1768) and their tech support suggested this change which fixed the problem. Instead of keeping the fix locally I think it's better to merge it upstream.