### PR TITLE
[RFC] Implementing soft_uart for Arduino Due

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -19,8 +19,10 @@
 	#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_STM32F1)
 #endif
 
+#define SW_CAPABLE_PLATFORM true
+
 #if SW_CAPABLE_PLATFORM
-	#include <SoftwareSerial.h>
+	#include "soft_uart.h"
 #endif
 
 #include "source/SW_SPI.h"
@@ -964,6 +966,9 @@ class TMC2208Stepper : public TMCStepper {
 		INIT2208_REGISTER(CHOPCONF)		{{.sr=0}};
 		INIT2208_REGISTER(PWMCONF)		{{.sr=0}};
 
+		uint16_t SW_RX = -1;
+		uint16_t SW_TX = -1;
+
 		struct IFCNT_t 		{ constexpr static uint8_t address = 0x02; };
 		struct OTP_PROG_t 	{ constexpr static uint8_t address = 0x04; };
 		struct OTP_READ_t 	{ constexpr static uint8_t address = 0x05; };
@@ -975,7 +980,7 @@ class TMC2208Stepper : public TMCStepper {
 
 		Stream * HWSerial = NULL;
 		#if SW_CAPABLE_PLATFORM
-			SoftwareSerial * SWSerial = NULL;
+			arduino_due::soft_uart::serial<arduino_due::soft_uart::timer_ids::TIMER_TC4, 256, 256> * SWSerial = NULL;
 		#endif
 
 		void write(uint8_t, uint32_t);

--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -20,13 +20,19 @@ TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr) :
 		slave_address(addr),
 		write_only(!has_rx)
 		{
-			SoftwareSerial *SWSerialObj = new SoftwareSerial(SW_RX_pin, SW_TX_pin);
+			SW_RX = SW_RX_pin;
+			SW_TX = SW_TX_pin;
+			auto *SWSerialObj = new arduino_due::soft_uart::serial<arduino_due::soft_uart::timer_ids::TIMER_TC4, 256, 256>();
 			SWSerial = SWSerialObj;
 			defaults();
 		}
 
 	void TMC2208Stepper::beginSerial(uint32_t baudrate) {
-		if (SWSerial != NULL) SWSerial->begin(baudrate);
+		if (SWSerial != NULL) SWSerial->begin(SW_RX, SW_TX, baudrate,
+		                                      arduino_due::soft_uart::data_bit_codes::EIGHT_BITS,
+		                                      arduino_due::soft_uart::parity_codes::NO_PARITY,
+		                                      arduino_due::soft_uart::stop_bit_codes::ONE_STOP_BIT
+		                                     );
 	}
 #endif
 
@@ -177,9 +183,9 @@ uint32_t TMC2208Stepper::read(uint8_t addr) {
 	for (uint8_t i = 0; i < max_retries; i++) {
 		#if SW_CAPABLE_PLATFORM
 			if (SWSerial != NULL) {
-					SWSerial->listen();
+					//SWSerial.listen();
 					out = _sendDatagram(*SWSerial, datagram, len, abort_window);
-					SWSerial->stopListening();
+					//SWSerial.stopListening();
 			} else
 		#endif
 			{


### PR DESCRIPTION
I tried implementing soft_uart for the Arduino Due.
Right now it's replacing the official Arduino SoftwareSerial

It compiles through but I haven't tested it on my Arduino yet.

This is more or less a response to @teemuatlut in #23. To show how similar the API actually is.
I hope this is enough preparatory work for someone better capable than me to finish implementing this library. Or at least start a discussion on exactly what needs to be done to make this pull request ready to merge.
