### PR TITLE
add SPI daisy chain capability

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -362,7 +362,6 @@ class TMC2130Stepper : public TMCStepper {
 		const uint16_t _pinCS;
 		SW_SPIClass * TMC_SW_SPI = NULL;
 		static constexpr float default_RS = 0.11;
-
 };
 
 class TMC2160Stepper : public TMC2130Stepper {

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -13,7 +13,7 @@
 #include <Stream.h>
 #include <SPI.h>
 
-#ifdef __has_include
+#if (__cplusplus == 201703L) && defined(__has_include)
 	#define SW_CAPABLE_PLATFORM __has_include(<SoftwareSerial.h>)
 #else
 	#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_STM32F1)
@@ -46,8 +46,6 @@
 #define SET_ALIAS(TYPE, DRIVER, NEW, ARG, OLD) TYPE (DRIVER::*NEW)(ARG) = &DRIVER::OLD
 
 #define TMCSTEPPER_VERSION 0x000406 // v0.4.6
-
-#define MAX_TMC_STEPPERS  21  // max number of TMC steppers + 1
 
 class TMCStepper {
 	public:
@@ -137,9 +135,9 @@ class TMCStepper {
 
 class TMC2130Stepper : public TMCStepper {
 	public:
-		TMC2130Stepper(uint16_t pinCS, float RS = default_RS);
-		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
-		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
+		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		void begin();
 		void defaults();
 		void setSPISpeed(uint32_t speed);
@@ -329,15 +327,6 @@ class TMC2130Stepper : public TMCStepper {
 
 		uint8_t status_response;
 
-
-    // SPI chain
-    static uint8_t TMC_chain[MAX_TMC_STEPPERS];
-     // [0] - number of drivers in chain
-     // [1]... axis index for first device in the chain (closest to MOSI)
-    uint8_t axis_index;
-    uint8_t chain_pos = 0;  // 0 - not part of a chain
-    void set_chain_info(const uint8_t axis_index, const uint8_t chain_position);
-
 	protected:
 		void write(uint8_t addressByte, uint32_t config);
 		uint32_t read(uint8_t addressByte);
@@ -362,13 +351,16 @@ class TMC2130Stepper : public TMCStepper {
 		const uint16_t _pinCS;
 		SW_SPIClass * TMC_SW_SPI = NULL;
 		static constexpr float default_RS = 0.11;
+
+		int8_t link_index;
+		static int8_t chain_length;
 };
 
 class TMC2160Stepper : public TMC2130Stepper {
 	public:
-		TMC2160Stepper(uint16_t pinCS, float RS = default_RS);
-		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
-		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
+		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		void begin();
 		void defaults();
 		void push();
@@ -465,9 +457,9 @@ class TMC2160Stepper : public TMC2130Stepper {
 
 class TMC5130Stepper : public TMC2160Stepper {
 	public:
-		TMC5130Stepper(uint16_t pinCS, float RS = default_RS);
-		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
-		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
+		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 
 		void begin();
 		void defaults();
@@ -712,9 +704,9 @@ class TMC5130Stepper : public TMC2160Stepper {
 
 class TMC5160Stepper : public TMC5130Stepper {
 	public:
-		TMC5160Stepper(uint16_t pinCS, float RS = default_RS);
-		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
-		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
+		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 
 		void rms_current(uint16_t mA) { TMC2160Stepper::rms_current(mA); }
 		void rms_current(uint16_t mA, float mult) { TMC2160Stepper::rms_current(mA, mult); }
@@ -806,11 +798,11 @@ class TMC5160Stepper : public TMC5130Stepper {
 
 class TMC5161Stepper : public TMC5160Stepper {
 	public:
-		TMC5161Stepper(uint16_t pinCS, float RS = default_RS) : TMC5160Stepper(pinCS, RS) {}
-		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
-			TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK) {}
-		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
-			TMC5160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK) {}
+    TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) : TMC5160Stepper(pinCS, RS, link_index) {}
+		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
+			TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK, link_index) {}
+		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
+			TMC5160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link_index) {}
 };
 
 class TMC2208Stepper : public TMCStepper {

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -105,14 +105,6 @@ class TMCStepper {
 		int16_t cur_a();
 		int16_t cur_b();
 
-    // SPI chain
-    static uint8_t TMC_chain[MAX_TMC_STEPPERS];
-     // [0] - number of drivers in chain
-     // [1]... axis index for first device in the chain (closest to MOSI)
-    uint8_t axis_index;
-    uint8_t chain_pos = 0;  // 0 - not part of a chain
-    void set_chain_info(const uint8_t axis_index, const uint8_t chain_position);
-
 	protected:
 		TMCStepper(float RS) : Rsense(RS) {};
 		INIT_REGISTER(IHOLD_IRUN){{.sr=0}};	// 32b
@@ -337,6 +329,15 @@ class TMC2130Stepper : public TMCStepper {
 
 		uint8_t status_response;
 
+
+    // SPI chain
+    static uint8_t TMC_chain[MAX_TMC_STEPPERS];
+     // [0] - number of drivers in chain
+     // [1]... axis index for first device in the chain (closest to MOSI)
+    uint8_t axis_index;
+    uint8_t chain_pos = 0;  // 0 - not part of a chain
+    void set_chain_info(const uint8_t axis_index, const uint8_t chain_position);
+
 	protected:
 		void write(uint8_t addressByte, uint32_t config);
 		uint32_t read(uint8_t addressByte);
@@ -361,15 +362,7 @@ class TMC2130Stepper : public TMCStepper {
 		const uint16_t _pinCS;
 		SW_SPIClass * TMC_SW_SPI = NULL;
 		static constexpr float default_RS = 0.11;
-    
-    void TMC_SW_SPI_transfer_40(uint8_t addressByte, uint32_t config=0);
-    uint32_t TMC_SW_SPI_read_40(uint8_t addressByte);
-    void TMC_HW_SPI_transfer_40(uint8_t addressByte, uint32_t config=0);
-    uint32_t TMC_HW_SPI_read_40(uint8_t addressByte);
-    void TMC_SPI_chain_transfer_40(uint8_t addressByte, uint32_t config=0);      
-    uint32_t TMC_SPI_chain_read_40(uint8_t addressByte);
-      
-    
+
 };
 
 class TMC2160Stepper : public TMC2130Stepper {

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -47,6 +47,8 @@
 
 #define TMCSTEPPER_VERSION 0x000406 // v0.4.6
 
+#define MAX_TMC_STEPPERS  21  // max number of TMC steppers + 1
+
 class TMCStepper {
 	public:
 		uint16_t cs2rms(uint8_t CS);
@@ -102,6 +104,14 @@ class TMCStepper {
 		uint32_t MSCURACT();
 		int16_t cur_a();
 		int16_t cur_b();
+
+    // SPI chain
+    static uint8_t TMC_chain[MAX_TMC_STEPPERS];
+     // [0] - number of drivers in chain
+     // [1]... axis index for first device in the chain (closest to MOSI)
+    uint8_t axis_index;
+    uint8_t chain_pos = 0;  // 0 - not part of a chain
+    void set_chain_info(const uint8_t axis_index, const uint8_t chain_position);
 
 	protected:
 		TMCStepper(float RS) : Rsense(RS) {};
@@ -351,6 +361,15 @@ class TMC2130Stepper : public TMCStepper {
 		const uint16_t _pinCS;
 		SW_SPIClass * TMC_SW_SPI = NULL;
 		static constexpr float default_RS = 0.11;
+    
+    void TMC_SW_SPI_transfer_40(uint8_t addressByte, uint32_t config=0);
+    uint32_t TMC_SW_SPI_read_40(uint8_t addressByte);
+    void TMC_HW_SPI_transfer_40(uint8_t addressByte, uint32_t config=0);
+    uint32_t TMC_HW_SPI_read_40(uint8_t addressByte);
+    void TMC_SPI_chain_transfer_40(uint8_t addressByte, uint32_t config=0);      
+    uint32_t TMC_SPI_chain_read_40(uint8_t addressByte);
+      
+    
 };
 
 class TMC2160Stepper : public TMC2130Stepper {

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -112,8 +112,10 @@ uint32_t TMC2130Stepper::read(uint8_t addressByte) {
     TMC_SW_SPI->transfer(addressByte & 0xFF);
     TMC_SW_SPI->transfer16(0x0000); // Clear SPI
     TMC_SW_SPI->transfer16(0x0000);
+    
     switchCSpin(HIGH);
     switchCSpin(LOW);
+    
     status_response = TMC_SW_SPI->transfer(addressByte & 0xFF); // Send the address byte again
     out  = TMC_SW_SPI->transfer(0x00);
     out <<= 8;
@@ -122,14 +124,17 @@ uint32_t TMC2130Stepper::read(uint8_t addressByte) {
     out |= TMC_SW_SPI->transfer(0x00);
     out <<= 8;
     out |= TMC_SW_SPI->transfer(0x00);
+    
   } else {
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
     SPI.transfer(addressByte & 0xFF);
     SPI.transfer16(0x0000); // Clear SPI
     SPI.transfer16(0x0000);
+    
     switchCSpin(HIGH);
     switchCSpin(LOW);
+    
     status_response = SPI.transfer(addressByte & 0xFF); // Send the address byte again
     out  = SPI.transfer(0x00);
     out <<= 8;
@@ -138,6 +143,7 @@ uint32_t TMC2130Stepper::read(uint8_t addressByte) {
     out |= SPI.transfer(0x00);
     out <<= 8;
     out |= SPI.transfer(0x00);
+    
     SPI.endTransaction();
   }
   switchCSpin(HIGH);
@@ -151,7 +157,7 @@ void TMC2130Stepper::write(uint8_t addressByte, uint32_t config) {
       switchCSpin(LOW);
       for (uint8_t i = TMC_chain[0]; i != 0; i--)
         if (axis_index == TMC_chain[i]) {
-          TMC_SW_SPI->transfer(addressByte & 0xFF);
+          status_response = TMC_SW_SPI->transfer(addressByte & 0xFF);
           TMC_SW_SPI->transfer16((config>>16) & 0xFFFF);
           TMC_SW_SPI->transfer16(config & 0xFFFF);
         }
@@ -163,7 +169,7 @@ void TMC2130Stepper::write(uint8_t addressByte, uint32_t config) {
       switchCSpin(LOW);
       for (uint8_t i = TMC_chain[0]; i != 0; i--)
         if (axis_index == TMC_chain[i]) {
-          SPI.transfer(addressByte & 0xFF);
+          status_response = SPI.transfer(addressByte & 0xFF);
           SPI.transfer16((config>>16) & 0xFFFF);
           SPI.transfer16(config & 0xFFFF);
         }
@@ -173,13 +179,13 @@ void TMC2130Stepper::write(uint8_t addressByte, uint32_t config) {
     }
   } else if (TMC_SW_SPI != NULL) {
     switchCSpin(LOW);
-    TMC_SW_SPI->transfer(addressByte & 0xFF);
+    status_response = TMC_SW_SPI->transfer(addressByte & 0xFF);
     TMC_SW_SPI->transfer16((config>>16) & 0xFFFF);
     TMC_SW_SPI->transfer16(config & 0xFFFF);
   } else {
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
-    SPI.transfer(addressByte & 0xFF);
+    status_response = SPI.transfer(addressByte & 0xFF);
     SPI.transfer16((config>>16) & 0xFFFF);
     SPI.transfer16(config & 0xFFFF);
     SPI.endTransaction();

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -112,10 +112,10 @@ uint32_t TMC2130Stepper::read(uint8_t addressByte) {
     TMC_SW_SPI->transfer(addressByte & 0xFF);
     TMC_SW_SPI->transfer16(0x0000); // Clear SPI
     TMC_SW_SPI->transfer16(0x0000);
-    
+
     switchCSpin(HIGH);
     switchCSpin(LOW);
-    
+
     status_response = TMC_SW_SPI->transfer(addressByte & 0xFF); // Send the address byte again
     out  = TMC_SW_SPI->transfer(0x00);
     out <<= 8;
@@ -124,17 +124,17 @@ uint32_t TMC2130Stepper::read(uint8_t addressByte) {
     out |= TMC_SW_SPI->transfer(0x00);
     out <<= 8;
     out |= TMC_SW_SPI->transfer(0x00);
-    
+
   } else {
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
     SPI.transfer(addressByte & 0xFF);
     SPI.transfer16(0x0000); // Clear SPI
     SPI.transfer16(0x0000);
-    
+
     switchCSpin(HIGH);
     switchCSpin(LOW);
-    
+
     status_response = SPI.transfer(addressByte & 0xFF); // Send the address byte again
     out  = SPI.transfer(0x00);
     out <<= 8;
@@ -143,7 +143,7 @@ uint32_t TMC2130Stepper::read(uint8_t addressByte) {
     out |= SPI.transfer(0x00);
     out <<= 8;
     out |= SPI.transfer(0x00);
-    
+
     SPI.endTransaction();
   }
   switchCSpin(HIGH);

--- a/src/source/TMC2160Stepper.cpp
+++ b/src/source/TMC2160Stepper.cpp
@@ -1,13 +1,13 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS) : TMC2130Stepper(pinCS, RS)
+TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2130Stepper(pinCS, RS, link)
   { defaults(); }
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
-  TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK)
+TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
+  TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
-  TMC2130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK)
+TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
+  TMC2130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }
 
 void TMC2160Stepper::begin() {

--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -1,13 +1,13 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS) : TMC2160Stepper(pinCS, RS)
+TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2160Stepper(pinCS, RS, link)
   { defaults(); }
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
-  TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK)
+TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link):
+  TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
-  TMC2160Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK)
+TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
+  TMC2160Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }
 
 void TMC5130Stepper::begin() {

--- a/src/source/TMC5160Stepper.cpp
+++ b/src/source/TMC5160Stepper.cpp
@@ -1,13 +1,13 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS) : TMC5130Stepper(pinCS, RS)
+TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC5130Stepper(pinCS, RS, link)
   { defaults(); }
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
-  TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK)
+TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
+  TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
-  TMC5130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK)
+TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
+  TMC5130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }
 
 void TMC5160Stepper::defaults() {

--- a/src/source/TMCStepper.cpp
+++ b/src/source/TMCStepper.cpp
@@ -151,17 +151,3 @@ int16_t TMCStepper::cur_b() {
   if (value > 255) value -= 512;
   return value;
 }
-
-uint8_t TMCStepper::TMC_chain[MAX_TMC_STEPPERS];
-
-// Add to the chain array and save chain info for this stepper
-void TMCStepper::set_chain_info(const uint8_t axis, const uint8_t chain_position=0) {
-  if (chain_position) {
-    TMC_chain[0]++;
-    TMC_chain[chain_position] = axis;
-    chain_pos = chain_position;
-    axis_index = axis;
-  }
-  else
-    TMC_chain[0] = 0;  // Reset array back to uninitialized
-}

--- a/src/source/TMCStepper.cpp
+++ b/src/source/TMCStepper.cpp
@@ -151,3 +151,17 @@ int16_t TMCStepper::cur_b() {
   if (value > 255) value -= 512;
   return value;
 }
+
+uint8_t TMCStepper::TMC_chain[MAX_TMC_STEPPERS];
+
+// Add to the chain array and save chain info for this stepper
+void TMCStepper::set_chain_info(const uint8_t axis, const uint8_t chain_position=0) {
+  if (chain_position) {
+    TMC_chain[0]++;
+    TMC_chain[chain_position] = axis;
+    chain_pos = chain_position;
+    axis_index = axis;
+  }
+  else
+    TMC_chain[0] = 0;  // Reset array back to uninitialized
+}


### PR DESCRIPTION
This PR adds the ability to use SPI daisy chaining.  This allows the use of just four pins no matter how many drivers are in the chain.

The daisy chain routines are based on the L6470 daisy chain routines in Marlin.

The code changes have been tested on a modified RAMPS-FD V2 using TMC2130 and TMC5160 drivers in one and four driver chains.  Only the soft SPI mode was tested.

See [PR #15081](https://github.com/MarlinFirmware/Marlin/pull/15081) for the Marlin side of the changes.

---

The array **TMC_chain[]** is used to hold the information as to the order in which the drivers are chained.
```
  [0] - number of drivers in chain
  [1] - axis_index for first device in the chain (closest to MOSI)
  [2] - axis_index for next device in the chain
```

**axis index** is an unique arbitrary number assigned by the application to the axis that a driver powers.  

`void set_chain_info(const uint8_t axis_index, const uint8_t chain_position);` is used by the application to populate **TMC_chain[]** and to save the **axis_index** in the stepper object.  This must be done after the steppers objects have all been created and before the drivers are initialized.

Wrappers were added to the **read** and **write** functions to implement the daisy chain functionality.  All the wrappers do is:
1. Scan the TMC_chain[] backwards (data for the driver furthest from MOSI is sent first).
2. If the contents of TMC_chain[i] matches the axis_index of the stepper object then the data is sent using the appropriate (standard) TMC SW or HW SPI driver.  If there isn't a match then five dummy bytes are sent (contents are 0x00).

The TMC2130 SPI read and SPI write routines were re-arranged and broken out into subroutines to make it easier to understand the logic flow.

---

**TO DO**

- Look at adding a TMC_CHAIN_CS define so that the rule of using just a single chip select is automatically enforced.  
- Look at moving all SPI daisy chain class items in the TMC2130 area.