### PR TITLE
Don't clobber GCONF_register if we can't read from the driver

### DIFF
--- a/src/source/CHOPCONF.cpp
+++ b/src/source/CHOPCONF.cpp
@@ -58,8 +58,10 @@ void TMC2208Stepper::CHOPCONF(uint32_t input) {
 	write(CHOPCONF_register.address, CHOPCONF_register.sr);
 }
 uint32_t TMC2208Stepper::CHOPCONF() {
+	CHOPCONF_t cc{0};
 	if (write_only) return CHOPCONF_register.sr;
-	CHOPCONF_register.sr = read(CHOPCONF_register.address);
+	cc.sr = read(CHOPCONF_register.address);
+	if (!CRCerror) CHOPCONF_register.sr = cc.sr;
 	return CHOPCONF_register.sr;
 }
 void TMC2208Stepper::toff	( uint8_t  B )	{ SET_REG(toff); 	}

--- a/src/source/GCONF.cpp
+++ b/src/source/GCONF.cpp
@@ -67,8 +67,10 @@ bool TMC5160Stepper::faststandstill()				{ GET_REG(faststandstill);			}
 bool TMC5160Stepper::multistep_filt()				{ GET_REG(multistep_filt);			}
 
 uint32_t TMC2208Stepper::GCONF() {
+	GCONF_t gc{0};
 	if (write_only) return GCONF_register.sr;
-	GCONF_register.sr = read(GCONF_register.address);
+	gc.sr = read(GCONF_register.address);
+	if (!CRCerror) GCONF_register.sr = gc.sr;
 	return GCONF_register.sr;
 }
 void TMC2208Stepper::GCONF(uint32_t input) {

--- a/src/source/PWMCONF.cpp
+++ b/src/source/PWMCONF.cpp
@@ -52,8 +52,10 @@ uint8_t TMC2160Stepper::pwm_reg()		{ return PWMCONF_register.pwm_reg;		}
 uint8_t TMC2160Stepper::pwm_lim()		{ return PWMCONF_register.pwm_lim;		}
 
 uint32_t TMC2208Stepper::PWMCONF() {
+	PWMCONF_t pwm{0};
 	if (write_only) return PWMCONF_register.sr;
-	PWMCONF_register.sr = read(PWMCONF_register.address);
+	pwm.sr = read(PWMCONF_register.address);
+	if (!CRCerror) PWMCONF_register.sr = pwm.sr;
 	return PWMCONF_register.sr;
 }
 void TMC2208Stepper::PWMCONF(uint32_t input) {

--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -251,8 +251,10 @@ bool TMC2224Stepper::dir()			{ TMC2224_n::IOIN_t r{0}; r.sr = IOIN(); return r.d
 uint8_t TMC2224Stepper::version() 	{ TMC2224_n::IOIN_t r{0}; r.sr = IOIN(); return r.version;	}
 
 uint16_t TMC2208Stepper::FACTORY_CONF() {
+	FACTORY_CONF_t fc{0};
 	if (write_only) return FACTORY_CONF_register.sr;
-	FACTORY_CONF_register.sr = read(FACTORY_CONF_register.address);
+	fc.sr = read(FACTORY_CONF_register.address);
+	if (!CRCerror) FACTORY_CONF_register.sr = fc.sr;
 	return FACTORY_CONF_register.sr;
 }
 void TMC2208Stepper::FACTORY_CONF(uint16_t input) {


### PR DESCRIPTION
This fixes https://github.com/MarlinFirmware/Marlin/issues/15055.