### PR TITLE
Define SW_CAPABLE_PLATFORM based on the version of Arduino Core STM32

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -16,7 +16,7 @@
 #if (__cplusplus == 201703L) && defined(__has_include)
 	#define SW_CAPABLE_PLATFORM __has_include(<SoftwareSerial.h>)
 #else
-	#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_STM32)
+	#define SW_CAPABLE_PLATFORM defined(__AVR__) || defined(TARGET_LPC1768) || (defined(ARDUINO_ARCH_STM32) && (!defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION >= 0x01070000)))
 #endif
 
 #if SW_CAPABLE_PLATFORM

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -20,6 +20,9 @@
 #endif
 
 #if SW_CAPABLE_PLATFORM
+	#if defined(ARDUINO_ARCH_STM32) && defined (TIM6_BASE)
+		#define TIMER_SERIAL TIM6
+	#endif
 	#include <SoftwareSerial.h>
 #endif
 


### PR DESCRIPTION
SoftwareSerial is supported in the Arduino Core STM32 from version 1.7 and up.

Added a check that the version is >= 1.7.
