### PR TITLE
Keep serial pin high high state when idle

### DIFF
--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -34,6 +34,12 @@ TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint
 
 	void TMC2208Stepper::beginSerial(uint32_t baudrate) {
 		if (SWSerial != NULL) SWSerial->begin(baudrate);
+		#if defined(ARDUINO_ARCH_AVR)
+			if (RXTX_pin > 0) {
+				digitalWrite(RXTX_pin, HIGH);
+				pinMode(RXTX_pin, OUTPUT);
+			}
+		#endif
 	}
 #endif
 
@@ -136,8 +142,7 @@ uint64_t TMC2208Stepper::_sendDatagram(SERIAL_TYPE &serPtr, uint8_t datagram[], 
 
 	#if defined(ARDUINO_ARCH_AVR)
 		if (RXTX_pin > 0) {
-			digitalWrite(RXTX_pin, HIGH);
-			pinMode(RXTX_pin, INPUT);
+			pinMode(RXTX_pin, INPUT_PULLUP);
 		}
 	#endif
 
@@ -188,7 +193,15 @@ uint64_t TMC2208Stepper::_sendDatagram(SERIAL_TYPE &serPtr, uint8_t datagram[], 
 		i++;
 	}
 
+	#if defined(ARDUINO_ARCH_AVR)
+		if (RXTX_pin > 0) {
+			digitalWrite(RXTX_pin, HIGH);
+			pinMode(RXTX_pin, OUTPUT);
+		}
+	#endif
+
 	while (serPtr.available() > 0) serPtr.read(); // Flush
+
 	return out;
 }
 


### PR DESCRIPTION
The UART interface of TMC drivers is unreliable if the UART pin is not held high when idle. This is typical for serial in general, but specifically called out int the TMC2008 datasheet.

![image](https://user-images.githubusercontent.com/20053467/69007846-458cfa00-08f8-11ea-9b66-0e18dfabf8c4.png)

Failing to do this causes connections which appear to work, but sporadically write and read incorrect values.

This change maintains a logic high state as much as possible between operations, by initializing the output high during _begin_ and immediately after a read.

It is not enough to simply pull the line high, because a lot of existing 3D printer hardware pulls the UART pin down, so that driver modules will default to standalone mode if the UART is not connected.

I'm including several pictures below to compare the behavior of 2-pin, 1-pin as in master, and 1-pin with this change applied.

Each image has two analog captures, both of BigTreeTech TMC2208-V3.0 (UART) modules. The yellow line has the default pull-down resistor. The red line has the default pull-down resistor removed.

**2 Pin Serial - Writes during reset**
![2Wire_Reset](https://user-images.githubusercontent.com/20053467/69007915-1034dc00-08f9-11ea-8617-413c8d40eddb.png)

**2 Pin Serial - Reading DRVSTATUS**
![2Wire_DRVSTATUS](https://user-images.githubusercontent.com/20053467/69007917-14f99000-08f9-11ea-8c8e-3986be665a8c.png)

**1 Pin Serial (current master) - Writes during reset**
![1Wire_Master_Reset](https://user-images.githubusercontent.com/20053467/69007920-1925ad80-08f9-11ea-93d1-def9cc7648a0.png)

**1 Pin Serial (current master) - Reading DRVSTATUS**
![1Wire_Master_DRVSTATUS](https://user-images.githubusercontent.com/20053467/69007921-20e55200-08f9-11ea-9942-e3eb709638b1.png)

**1 Pin Serial (this change) - Writes during reset**
![1Wire_Jason_Reset](https://user-images.githubusercontent.com/20053467/69007923-23e04280-08f9-11ea-9af9-2120a063dd16.png)

**1 Pin Serial (this change) - Reading DRVSTATUS**
There is still a short period after each read when the line is an input and the state is invalid. This is after the read is complete, and does not seem to interfere with proper operation.
![1Wire_Jason_DRVSTATUS](https://user-images.githubusercontent.com/20053467/69007912-090dce00-08f9-11ea-8ee6-b0ac248ceda1.png)

