### PR TITLE
Stop listening after starting SoftwareSerial

### DIFF
--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -33,7 +33,11 @@ TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint
 		}
 
 	void TMC2208Stepper::beginSerial(uint32_t baudrate) {
-		if (SWSerial != NULL) SWSerial->begin(baudrate);
+		if (SWSerial != NULL)
+		{
+			SWSerial->begin(baudrate);
+			SWSerial->stopListening();
+		}
 		#if defined(ARDUINO_ARCH_AVR)
 			if (RXTX_pin > 0) {
 				digitalWrite(RXTX_pin, HIGH);


### PR DESCRIPTION
Some platforms such as LPC176x call listen() inside their begin() function. This is done due to precedent from the original AVR implementation.

This causes problems for single-pin half-duplex, because it causes the pin mode to switch to input after each write command, even if the TMC will not send a response. This can leave the line in an indeterminate state, preventing the TMC from recognizing the start bit of the next command.

To resolve this, we can call stopListening() immediately after calling begin(). This prevents the automatic transition to input after the write completes.

Captures of Z and E drivers on an SKR 1.3, prior to the change. This issue only impacts only the last driver, because only one SoftwareSerial instance can listen at a time. These are the first interactions with the drivers after power-on.

![image](https://user-images.githubusercontent.com/20053467/69487314-8d39e700-0e0c-11ea-8b3b-51a8336312e3.png)

Same capture with this change:

![image](https://user-images.githubusercontent.com/20053467/69487323-a2167a80-0e0c-11ea-96cb-7dc6fdabe4ae.png)




