### PR TITLE
Format CHOPPER_TIMING as an array

### DIFF
--- a/examples/Calibrate_spreadCycle/Calibrate_spreadCycle.ino
+++ b/examples/Calibrate_spreadCycle/Calibrate_spreadCycle.ino
@@ -173,12 +173,13 @@ void setup() {
     Serial.print(F(" = "));
     Serial.println(config.hysteresis_end + config.hysteresis_start);
     Serial.println(F("Your configuration parameters in Marlin are:"));
-    Serial.print(F("#define CHOPPER_TIMING "));
+    Serial.print(F("#define CHOPPER_TIMING { "));
     Serial.print(config.off_time);
-    Serial.print(F(" "));
+    Serial.print(F(", "));
     Serial.print(config.hysteresis_end);
-    Serial.print(F(" "));
+    Serial.print(F(", "));
     Serial.print(config.hysteresis_start);
+    Serial.println(F(" }"));
 }
 
 void initPins() {


### PR DESCRIPTION
This PR modifies the spreadCycle calibration helper to output the Marlin config option `CHOPPER_TIMING` as an array.