### PR TITLE
Allow all architectures to avoid warning

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library for Trinamic stepper drivers
 paragraph=Easily configure your Trinamic stepper motor drivers
 category=Device Control
 url=https://github.com/teemuatlut/TMCStepper
-architectures=avr
+architectures=*


### PR DESCRIPTION
The project Grbl_Esp32 uses this library and has to comment about the architecture warning in 

https://github.com/bdring/Grbl_Esp32/wiki/Compiling-the-firmware

"WARNING: library TMCStepper claims to run on avr architecture(s)". Clearly it is working for architectures other than AVR :)