### PR TITLE
Fixed a bug in bcm2835_stream.cpp's begin() so that pi linux serial UART now uses 8N1 config

### DIFF
--- a/src/source/bcm2835_stream.cpp
+++ b/src/source/bcm2835_stream.cpp
@@ -28,9 +28,12 @@ void Stream::begin(unsigned long baud, int flags)
 	}
 	fcntl(fd, F_SETFL, O_RDWR);
 
+	// Use 8 data bit, no parity and 1 stop bit
 	tcgetattr(fd, &options);
 	options.c_cflag = CS8 | CLOCAL | CREAD | CBAUDEX;
-	options.c_cflag &= ~CBAUD;
+	options.c_cflag &= ~CBAUD;	// use the extended baud
+	options.c_cflag &= ~PARENB;	// no parity
+	options.c_cflag &= ~CSTOPB;	// 1 stop bit
 	options.c_iflag = IGNPAR;
 	options.c_oflag = baud;
 	options.c_lflag = baud;


### PR DESCRIPTION
 * Tried to port Simple.ino example to the pi linux and somehow nothing was able to run properly even after wires were checked. After some investigation, problem lies on pi linux uart serial configuration.
 * UART Stream class now uses 8N1 so the signal is now compatible to TMC2208/TMC2209 PND_UART and shaft = !shaft based on the example now switches direction alternatively while the DIR is physically set to low.