### PR TITLE
ESP-IDF Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRC_DIRS src/source
+                       INCLUDE_DIRS "src"
+)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wfatal-errors)

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -14,6 +14,9 @@
 	#include <bcm2835.h>
 	#include "source/bcm2835_spi.h"
 	#include "source/bcm2835_stream.h"
+#elif defined(ESP_PLATFORM)
+	#include "source/ESP32_Serial.h"
+	#include "source/ESP32_SPI.h"
 #endif
 
 #if (__cplusplus == 201703L) && defined(__has_include)
@@ -141,7 +144,9 @@ class TMCStepper {
 
 class TMC2130Stepper : public TMCStepper {
 	public:
-		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#if !defined(ESP_PLATFORM)
+			TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#endif
 		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		void begin();
@@ -368,7 +373,9 @@ class TMC2130Stepper : public TMCStepper {
 
 class TMC2160Stepper : public TMC2130Stepper {
 	public:
-		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#if !defined(ESP_PLATFORM)
+			TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#endif
 		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		void begin();
@@ -467,7 +474,9 @@ class TMC2160Stepper : public TMC2130Stepper {
 
 class TMC5130Stepper : public TMC2160Stepper {
 	public:
-		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#if !defined(ESP_PLATFORM)
+			TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#endif
 		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 
@@ -711,7 +720,9 @@ class TMC5130Stepper : public TMC2160Stepper {
 
 class TMC5160Stepper : public TMC5130Stepper {
 	public:
-		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#if !defined(ESP_PLATFORM)
+			TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#endif
 		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 
@@ -805,19 +816,28 @@ class TMC5160Stepper : public TMC5130Stepper {
 
 class TMC5161Stepper : public TMC5160Stepper {
 	public:
-    TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) : TMC5160Stepper(pinCS, RS, link_index) {}
-		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
-			TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK, link_index) {}
-		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
-			TMC5160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link_index) {}
+	#if !defined(ESP_PLATFORM)
+    	TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) : TMC5160Stepper(pinCS, RS, link_index) {}
+	#endif
+	TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
+		TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK, link_index) {}
+	TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
+		TMC5160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link_index) {}
 };
 
 class TMC2208Stepper : public TMCStepper {
 	public:
-	    TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint16_t mul_pin1, uint16_t mul_pin2);
-		TMC2208Stepper(Stream * SerialPort, float RS) :
-			TMC2208Stepper(SerialPort, RS, TMC2208_SLAVE_ADDR)
-			{}
+		#if defined(ESP_PLATFORM)
+			TMC2208Stepper( ESP32_Serial * SerialPort, float RS, uint8_t addr, uint16_t mul_pin1, uint16_t mul_pin2);
+			TMC2208Stepper( ESP32_Serial * SerialPort, float RS) :
+				TMC2208Stepper(SerialPort, RS, TMC2208_SLAVE_ADDR)
+				{}
+		#else
+			TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint16_t mul_pin1, uint16_t mul_pin2);
+			TMC2208Stepper(Stream * SerialPort, float RS) :
+				TMC2208Stepper(SerialPort, RS, TMC2208_SLAVE_ADDR)
+				{}
+		#endif
 		#if SW_CAPABLE_PLATFORM
 			TMC2208Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS) :
 				TMC2208Stepper(SW_RX_pin, SW_TX_pin, RS, TMC2208_SLAVE_ADDR)
@@ -988,12 +1008,17 @@ class TMC2208Stepper : public TMCStepper {
 		struct OTP_PROG_t 	{ constexpr static uint8_t address = 0x04; };
 		struct OTP_READ_t 	{ constexpr static uint8_t address = 0x05; };
 
-		TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr);
+		#if defined(ESP_PLATFORM)
+			TMC2208Stepper(ESP32_Serial * SerialPort, float RS, uint8_t addr);
+			ESP32_Serial * HWSerial = nullptr;
+		#else
+			TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr);
+			Stream * HWSerial = nullptr;
+		#endif
 		#if SW_CAPABLE_PLATFORM
 			TMC2208Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, uint8_t addr);
 		#endif
 
-		Stream * HWSerial = nullptr;
 		#if SW_CAPABLE_PLATFORM
 			SoftwareSerial * SWSerial = nullptr;
 			const uint16_t RXTX_pin = 0; // Half duplex
@@ -1020,11 +1045,15 @@ class TMC2208Stepper : public TMCStepper {
 
 		uint64_t _sendDatagram(uint8_t [], const uint8_t, uint16_t);
 };
-
 class TMC2209Stepper : public TMC2208Stepper {
 	public:
-		TMC2209Stepper(Stream * SerialPort, float RS, uint8_t addr) :
-			TMC2208Stepper(SerialPort, RS, addr) {}
+		#if defined(ESP_PLATFORM)
+			TMC2209Stepper(ESP32_Serial * SerialPort, float RS, uint8_t addr);
+			ESP32_Serial * HWSerial = nullptr;
+		#else
+			TMC2209Stepper(Stream * SerialPort, float RS, uint8_t addr) :
+				TMC2208Stepper(SerialPort, RS, addr) {}
+		#endif
 
 		#if SW_CAPABLE_PLATFORM
 			TMC2209Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, uint8_t addr) :

--- a/src/source/ESP32_Adapter.cpp
+++ b/src/source/ESP32_Adapter.cpp
@@ -1,0 +1,25 @@
+#include "ESP32_Adapter.h"
+
+#if defined(ESP_PLATFORM)
+    void pinMode( uint16_t num, gpio_dir_t mode ) {
+        switch( mode ) {
+            case OUTPUT:
+                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_OUTPUT );
+                break;
+            case INPUT:
+                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_INPUT );
+                gpio_set_pull_mode( (gpio_num_t)num, GPIO_FLOATING );
+                break;
+            case INPUT_PULLUP:
+                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_INPUT );
+                gpio_set_pull_mode( (gpio_num_t)num, GPIO_PULLUP_ONLY );
+                break;
+        }
+    }
+    void digitalWrite( uint16_t num, uint32_t level ) {
+        gpio_set_level( (gpio_num_t)num, level );
+    }
+    int digitalRead( uint16_t num ) {
+        return gpio_get_level( (gpio_num_t)num );
+    }
+#endif

--- a/src/source/ESP32_Adapter.h
+++ b/src/source/ESP32_Adapter.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#if defined(ESP_PLATFORM)
+    #include <cstdint>
+    #include <driver/gpio.h>
+    #define LOW  0
+    #define HIGH 1
+    typedef enum {
+        OUTPUT,
+        INPUT,
+        INPUT_PULLUP
+    } gpio_dir_t;
+    void pinMode( uint16_t num, gpio_dir_t mode ) {
+        switch( mode ) {
+            case OUTPUT:
+                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_OUTPUT );
+                break;
+            case INPUT:
+                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_INPUT );
+                gpio_set_pull_mode( (gpio_num_t)num, GPIO_FLOATING );
+                break;
+            case INPUT_PULLUP:
+                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_INPUT );
+                gpio_set_pull_mode( (gpio_num_t)num, GPIO_PULLUP_ONLY );
+                break;
+        }
+    }
+    void digitalWrite( uint16_t num, uint32_t level ) {
+        gpio_set_level( (gpio_num_t)num, level );
+    }
+    int digitalRead( uint16_t num ) {
+        return gpio_get_level( (gpio_num_t)num );
+    }
+#endif

--- a/src/source/ESP32_Adapter.h
+++ b/src/source/ESP32_Adapter.h
@@ -10,25 +10,7 @@
         INPUT,
         INPUT_PULLUP
     } gpio_dir_t;
-    void pinMode( uint16_t num, gpio_dir_t mode ) {
-        switch( mode ) {
-            case OUTPUT:
-                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_OUTPUT );
-                break;
-            case INPUT:
-                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_INPUT );
-                gpio_set_pull_mode( (gpio_num_t)num, GPIO_FLOATING );
-                break;
-            case INPUT_PULLUP:
-                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_INPUT );
-                gpio_set_pull_mode( (gpio_num_t)num, GPIO_PULLUP_ONLY );
-                break;
-        }
-    }
-    void digitalWrite( uint16_t num, uint32_t level ) {
-        gpio_set_level( (gpio_num_t)num, level );
-    }
-    int digitalRead( uint16_t num ) {
-        return gpio_get_level( (gpio_num_t)num );
-    }
+    void pinMode( uint16_t num, gpio_dir_t mode );
+    void digitalWrite( uint16_t num, uint32_t level );
+    int digitalRead( uint16_t num );
 #endif

--- a/src/source/ESP32_SPI.cpp
+++ b/src/source/ESP32_SPI.cpp
@@ -1,0 +1,7 @@
+#if defined(ESP_PLATFORM)
+
+#include "ESP32_SPI.h"
+
+SPIClass SPI;
+
+#endif

--- a/src/source/ESP32_SPI.h
+++ b/src/source/ESP32_SPI.h
@@ -1,0 +1,48 @@
+#pragma once
+
+/*
+****************************************************
+DUMMY IMPLEMENTATION
+****************************************************
+DOES NOT ACTUALLY DO ANYTHING
+****************************************************
+*/
+
+#if defined(ESP_PLATFORM)
+
+#include <cstdint>
+
+#define MSBFIRST 0
+#define SPI_MODE0 0
+#define SPI_MODE1 1
+#define SPI_MODE2 2
+#define SPI_MODE3 3
+
+class SPIClass;
+
+struct SPISettings
+{
+	friend class SPIClass;
+	SPISettings(uint32_t s, uint32_t o, uint32_t m) {
+		speed = s;
+		order = o;
+		mode = m;
+	}
+
+	uint32_t speed;
+	uint32_t order;
+	uint32_t mode;
+};
+
+class SPIClass
+{
+public:
+	void beginTransaction(SPISettings settings) {}
+	void endTransaction() {}
+	uint8_t transfer(uint8_t) {
+		return 0;
+	}
+};
+
+extern SPIClass SPI;
+#endif

--- a/src/source/ESP32_Serial.cpp
+++ b/src/source/ESP32_Serial.cpp
@@ -1,0 +1,60 @@
+#include "ESP32_Serial.h"
+
+#if defined(ESP_PLATFORM)
+    #define LOG_LOCAL_LEVEL ESP_LOG_VERBOSE
+    #define TAG_EPS32_SERIAL "ESP32_UART"
+    #include <esp_log.h>
+    #include <hal/gpio_types.h>
+
+    ESP32_Serial::ESP32_Serial( int baud_rate, int rx_pin, int tx_pin, uart_port_t uart_num_new ) {
+        uart_num = uart_num_new;
+        ready = false;
+        uart_config_t uart_config = {
+            .baud_rate = baud_rate,
+            .data_bits = UART_DATA_8_BITS,
+            .parity    = UART_PARITY_DISABLE,
+            .stop_bits = UART_STOP_BITS_1,
+            .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+            .rx_flow_ctrl_thresh = 0,
+            .source_clk = UART_SCLK_APB,
+        };
+        if( ESP_OK == uart_driver_install( uart_num, 2048, 0, 0, NULL, 0 ) ) {
+            if( ESP_OK == uart_param_config( uart_num, &uart_config ) ) {
+                if( ESP_OK == uart_set_pin( uart_num, tx_pin, rx_pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE ) ) {
+                    ready = true;
+                }
+                else {
+                    ESP_LOGE( TAG_EPS32_SERIAL, "Unable to set UART pins." );
+                }
+            }
+            else {
+                ESP_LOGE( TAG_EPS32_SERIAL, "Unable to configure UART." );
+            }
+        }
+        else {
+            ESP_LOGE( TAG_EPS32_SERIAL, "Unable to install UART driver." );
+        }
+    }
+
+    int16_t ESP32_Serial::read() {
+        if( !ready ) return -1;
+        uint8_t data;
+        int len = uart_read_bytes( uart_num, &data, 1, 0 );
+        if( len < 1 ) return -1;
+        else return data;
+    }
+
+    uint8_t ESP32_Serial::write( const uint8_t data ) {
+        if( !ready ) return 0;
+        int len = uart_write_bytes( uart_num, (const char*)&data, 1);
+        if( len < 1 ) return 0;
+        else return len;
+    }
+
+    size_t ESP32_Serial::available() {
+        if( !ready ) return 0;
+        size_t len = 0;
+        if( ESP_OK == uart_get_buffered_data_len( uart_num, &len ) ) return len;
+        else return 0;
+    }
+#endif

--- a/src/source/ESP32_Serial.cpp
+++ b/src/source/ESP32_Serial.cpp
@@ -1,7 +1,7 @@
 #include "ESP32_Serial.h"
 
 #if defined(ESP_PLATFORM)
-    #define LOG_LOCAL_LEVEL ESP_LOG_VERBOSE
+    #define LOG_LOCAL_LEVEL ESP_LOG_INFO
     #define TAG_EPS32_SERIAL "ESP32_UART"
     #include <esp_log.h>
     #include <hal/gpio_types.h>
@@ -37,24 +37,42 @@
     }
 
     int16_t ESP32_Serial::read() {
-        if( !ready ) return -1;
-        uint8_t data;
+        if( !ready ) {
+            ESP_LOGE( TAG_EPS32_SERIAL, "Trying to read from not ready UART." );
+            return -1;
+        }
+        uint8_t data = 0;
         int len = uart_read_bytes( uart_num, &data, 1, 0 );
+        ESP_LOGD( TAG_EPS32_SERIAL, "Read data: %X (length %d)", data, len );
         if( len < 1 ) return -1;
         else return data;
     }
 
     uint8_t ESP32_Serial::write( const uint8_t data ) {
-        if( !ready ) return 0;
+        if( !ready ) {
+            ESP_LOGE( TAG_EPS32_SERIAL, "Trying to write to not ready UART." );
+            return 0;
+        }
+        ESP_LOGD( TAG_EPS32_SERIAL, "Write data: %X", data );
         int len = uart_write_bytes( uart_num, (const char*)&data, 1);
+        ESP_LOGD( TAG_EPS32_SERIAL, "Number of bytes written: %d", len );
         if( len < 1 ) return 0;
         else return len;
     }
 
     size_t ESP32_Serial::available() {
-        if( !ready ) return 0;
+        if( !ready ) {
+            ESP_LOGE( TAG_EPS32_SERIAL, "Trying to get available bytes from not ready UART." );
+            return 0;
+        }
         size_t len = 0;
-        if( ESP_OK == uart_get_buffered_data_len( uart_num, &len ) ) return len;
-        else return 0;
+        if( ESP_OK == uart_get_buffered_data_len( uart_num, &len ) ) {
+            ESP_LOGD( TAG_EPS32_SERIAL, "Number of bytes available: %d", len );
+            return len;
+        }
+        else {
+            ESP_LOGE( TAG_EPS32_SERIAL, "Error getting available bytes." );
+            return 0;
+        }
     }
 #endif

--- a/src/source/ESP32_Serial.h
+++ b/src/source/ESP32_Serial.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#if defined(ESP_PLATFORM)
+    #include <cstdint>
+
+    #include <driver/uart.h>
+
+    class ESP32_Serial {
+        public:
+            ESP32_Serial( int baud_rate, int rx_pin = 16, int tx_pin = 17, uart_port_t uart_num_new = UART_NUM_2 );
+
+            int16_t read();
+            uint8_t write( const uint8_t data );
+            size_t available();
+
+        private:
+            bool ready;
+            uart_port_t uart_num;
+    };
+#endif

--- a/src/source/SERIAL_SWITCH.cpp
+++ b/src/source/SERIAL_SWITCH.cpp
@@ -1,11 +1,12 @@
 #include "SERIAL_SWITCH.h"
+#include "ESP32_Adapter.h"
 
 SSwitch::SSwitch( const uint16_t pin1, const uint16_t pin2, const uint8_t address) :
   p1(pin1),
   p2(pin2),
   addr(address)
 	{
-		pinMode(pin1, OUTPUT);		
+    pinMode(pin1, OUTPUT);
     pinMode(pin2, OUTPUT);
 	}
 

--- a/src/source/SERIAL_SWITCH.h
+++ b/src/source/SERIAL_SWITCH.h
@@ -6,6 +6,7 @@
 	#include "source/bcm2835_spi.h"
 	#include "source/bcm2835_stream.h"
 #endif
+#include <cstdint>
 
 #include "TMC_platforms.h"
 

--- a/src/source/SW_SPI.cpp
+++ b/src/source/SW_SPI.cpp
@@ -1,4 +1,5 @@
 #include "SW_SPI.h"
+#include "ESP32_Adapter.h"
 
 SW_SPIClass::SW_SPIClass(uint16_t mosi, uint16_t miso, uint16_t sck) :
   mosi_pin(mosi),

--- a/src/source/SW_SPI.h
+++ b/src/source/SW_SPI.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #if defined(ARDUINO) && ARDUINO >= 100
 #include <Arduino.h>
 #elif defined(bcm2835)

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -4,16 +4,18 @@
 int8_t TMC2130Stepper::chain_length = 0;
 uint32_t TMC2130Stepper::spi_speed = 16000000/8;
 
-TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, int8_t link) :
-  TMCStepper(RS),
-  _pinCS(pinCS),
-  link_index(link)
+#if !defined(ESP_PLATFORM)
+  TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, int8_t link) :
+    TMCStepper(RS),
+    _pinCS(pinCS),
+    link_index(link)
   {
     defaults();
 
     if (link > chain_length)
       chain_length = link;
   }
+#endif
 
 TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
   TMCStepper(default_RS),

--- a/src/source/TMC2160Stepper.cpp
+++ b/src/source/TMC2160Stepper.cpp
@@ -1,8 +1,10 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2130Stepper(pinCS, RS, link)
-  { defaults(); }
+#if !defined(ESP_PLATFORM)
+  TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2130Stepper(pinCS, RS, link)
+    { defaults(); }
+#endif
 TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
   TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }

--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -1,8 +1,10 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2160Stepper(pinCS, RS, link)
-  { defaults(); }
+#if !defined(ESP_PLATFORM)
+  TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2160Stepper(pinCS, RS, link)
+    { defaults(); }
+#endif
 TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link):
   TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }

--- a/src/source/TMC5160Stepper.cpp
+++ b/src/source/TMC5160Stepper.cpp
@@ -1,8 +1,10 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC5130Stepper(pinCS, RS, link)
-  { defaults(); }
+#if !defined(ESP_PLATFORM)
+  TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC5130Stepper(pinCS, RS, link)
+    { defaults(); }
+#endif
 TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
   TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }

--- a/src/source/TMC_platforms.h
+++ b/src/source/TMC_platforms.h
@@ -1,3 +1,5 @@
+#include "ESP32_Adapter.h"
+
 #if defined(ARDUINO_ARCH_AVR) // 125kHz
   typedef volatile uint8_t* fastio_reg;
   typedef uint8_t fastio_bm;


### PR DESCRIPTION
Generally I prefer the original ESP-IDF instead of the Arduino framework, because it seems to me less magical and more predictable.
So I tried to make this library compile in ESP-IDF without Arduino. Took much less work than I feared, which I guess shows again that this library is very well made. Thanks to everybody involved.

What I did not implement in ESP-IDF is the SPI interface, because I do not have any experience in that field and at first glance I wasn't able to match the Arduino SPI interface and the ESP-IDF API. Maybe someone with more experience can have a look at that.
But then I'm not actually sure the hardware SPI is actually required, because the SW solution exists.
To make sure nobody uses it accidentally (and to make it compile) I conditionally removed the affected constructors when ESP-IDF platform is configured.

I was able to test it on my ESP32 board with a TCM2208 stepper, but I neither have Arduino in place to try it nor any other stepper driver. So I would probably a good idea if someone with Arduino and other stepper drivers would test it before merging it upstream.