### PR TITLE
Fixed bugs in bcm2835_stream.cpp's begin() to use different baud speed and to resolve general port or driver instability

### DIFF
--- a/src/source/bcm2835_stream.cpp
+++ b/src/source/bcm2835_stream.cpp
@@ -1,4 +1,5 @@
 #if defined(bcm2835)
+#include <cstring>
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>

--- a/src/source/bcm2835_stream.cpp
+++ b/src/source/bcm2835_stream.cpp
@@ -63,8 +63,9 @@ void Stream::begin(unsigned long baud, int flags)
 			return;
 	}
 
-
-	struct termios options {};	// Zeroed memory
+	// https://stackoverflow.com/questions/61531928/why-doesnt-initializing-a-c-struct-to-0-set-all-of-its-members-to-0
+	struct termios options;
+	memset( &options, 0, sizeof(options) );
 
 	tcgetattr(fd, &options);
 

--- a/src/source/bcm2835_stream.cpp
+++ b/src/source/bcm2835_stream.cpp
@@ -3,6 +3,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include "bcm2835_stream.h"
 
 uint32_t millis()
@@ -28,17 +29,86 @@ void Stream::begin(unsigned long baud, int flags)
 	}
 	fcntl(fd, F_SETFL, O_RDWR);
 
-	// Use 8 data bit, no parity and 1 stop bit
+
+	speed_t myBaud;
+	switch ( baud )
+	{
+		case      50:	myBaud =      B50; break;
+		case      75:	myBaud =      B75; break;
+		case     110:	myBaud =     B110; break;
+		case     134:	myBaud =     B134; break;
+		case     150:	myBaud =     B150; break;
+		case     200:	myBaud =     B200; break;
+		case     300:	myBaud =     B300; break;
+		case     600:	myBaud =     B600; break;
+		case    1200:	myBaud =    B1200; break;
+		case    1800:	myBaud =    B1800; break;
+		case    2400:	myBaud =    B2400; break;
+		case    4800:	myBaud =    B4800; break;
+		case    9600:	myBaud =    B9600; break;
+		case   19200:	myBaud =   B19200; break;
+		case   38400:	myBaud =   B38400; break;
+		case   57600:	myBaud =   B57600; break;
+		case  115200:	myBaud =  B115200; break;
+		case  230400:	myBaud =  B230400; break;
+		case  460800:	myBaud =  B460800; break;
+		case  500000:	myBaud =  B500000; break;
+		case  576000:	myBaud =  B576000; break;
+		case  921600:	myBaud =  B921600; break;
+		case 1000000:	myBaud = B1000000; break;
+		case 1152000:	myBaud = B1152000; break;
+		case 1500000:	myBaud = B1500000; break;
+		case 2000000:	myBaud = B2000000; break;
+		case 2500000:	myBaud = B2500000; break;
+		case 3000000:	myBaud = B3000000; break;
+		case 3500000:	myBaud = B3500000; break;
+		case 4000000:	myBaud = B4000000; break;
+
+		default:
+			printf("[ERROR] UART invalid baud: %ld for port: %s\n", baud, port);
+			return;
+	}
+
+
+	struct termios options;
+	memset( &options, 0, sizeof(options) );
+
 	tcgetattr(fd, &options);
-	options.c_cflag = CS8 | CLOCAL | CREAD | CBAUDEX;
-	options.c_cflag &= ~CBAUD;	// use the extended baud
-	options.c_cflag &= ~PARENB;	// no parity
-	options.c_cflag &= ~CSTOPB;	// 1 stop bit
-	options.c_iflag = IGNPAR;
-	options.c_oflag = baud;
-	options.c_lflag = baud;
-	tcflush(fd, TCIFLUSH);
+
+	cfmakeraw( &options );
+	cfsetispeed( &options, myBaud );
+	cfsetospeed( &options, myBaud );
+
+	// See: https://www.mkssoftware.com/docs/man5/struct_termios.5.asp
+	// Use 8 data bit, no parity and 1 stop bit
+	// Set bits per byte
+	options.c_cflag |= ( CREAD | CLOCAL ) ;   // turn on READ and ignore modem ctrl lines
+	// CBAUDEX no need to use extended baud; setting this for some reason shows incorrect timing on the oscilloscope for 9600 but OK for 57600
+	// Not setting it seems to be OK on the oscilloscope for both 9600 and 57600.
+	options.c_cflag &= ~PARENB;     // no parity
+	options.c_cflag &= ~CSTOPB;     // 1 stop bit
+	options.c_cflag &= ~CSIZE;      // reset number of bits mask
+	options.c_cflag |= CS8;         // 8 data bit
+	options.c_cflag &= ~CRTSCTS;   // no flow control
+
+	options.c_iflag &= ~(IXON | IXOFF | IXANY); // turn off s/w flow ctrl
+	options.c_iflag |= IGNPAR;       // ignore characters with parity errors
+
+	options.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG) ;    // make raw
+
+	options.c_oflag &= ~OPOST;  // make raw
+
+	// See: http://unixwiz.net/techtips/termios-vmin-vtime.html
+	options.c_cc[VMIN]  = 0;
+	// Cannot set VTIME to 0 as it creates more problems such as cannot read the driver properly.
+	options.c_cc[VTIME] = 100;       // VTIME defined as tenths of a second so 100 is actually 10 seconds
+
+	tcflush(fd, TCIOFLUSH); // flush both tx and rx
 	tcsetattr(fd, TCSANOW, &options);
+
+	// Maybe add 10ms delay (belt and braces) to let UART setup correctly
+	const int DELAY_MS_10 = 10;
+	usleep( 1000 * DELAY_MS_10 );
 }
 
 void Stream::end()

--- a/src/source/bcm2835_stream.cpp
+++ b/src/source/bcm2835_stream.cpp
@@ -55,15 +55,8 @@ void Stream::begin(unsigned long baud, int flags)
 		case  460800:	myBaud =  B460800; break;
 		case  500000:	myBaud =  B500000; break;
 		case  576000:	myBaud =  B576000; break;
-		case  921600:	myBaud =  B921600; break;
-		case 1000000:	myBaud = B1000000; break;
-		case 1152000:	myBaud = B1152000; break;
-		case 1500000:	myBaud = B1500000; break;
-		case 2000000:	myBaud = B2000000; break;
-		case 2500000:	myBaud = B2500000; break;
-		case 3000000:	myBaud = B3000000; break;
-		case 3500000:	myBaud = B3500000; break;
-		case 4000000:	myBaud = B4000000; break;
+
+		// The TMC2209 maxed out around 750kbaud so other enums after 576kbaud is not needed.
 
 		default:
 			printf("[ERROR] UART invalid baud: %ld for port: %s\n", baud, port);
@@ -71,8 +64,7 @@ void Stream::begin(unsigned long baud, int flags)
 	}
 
 
-	struct termios options;
-	memset( &options, 0, sizeof(options) );
+	struct termios options {};	// Zeroed memory
 
 	tcgetattr(fd, &options);
 


### PR DESCRIPTION
Fixed bugs and issues with bcm2835_stream.cpp's begin() so that pi linux serial UART can use different baud speed

 * Fixed bug where baud rate was always 9600 (presumably from OS default). Now it can be at higher speed and verified with oscilloscope.
 * Added general initialisation OS calls to ensure that data is raw for TMCSteppers (tested with TMC2208/2209) :
  ** This was because of some intermittent or instability issues (hard to verify) where sometimes when setting VACTUAL to a certain speed (or other settings), it seemed to be getting incorrect values.
  ** Also when weird issues happened, the signals on the oscilloscope often looked noisier than when it was working.
  ** However, this patch does not seem to make anything worse than before so OK to me.
 * Added a slight delay for belt and braces before begin ends to allow serial settings to propagate through nicely before using it.
 * Flushed both Tx and Rx before finishing function call.