### PR TITLE
Fixed recent issue introduced in making serial port stable and setting correct baud rate

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -1016,6 +1016,8 @@ class TMC2208Stepper : public TMCStepper {
 		void preReadCommunication();
 		int16_t serial_read();
 		uint8_t serial_write(const uint8_t data);
+		void serial_read_flush();
+		void serial_write_flush();
 		void postWriteCommunication();
 		void postReadCommunication();
 		void write(uint8_t, uint32_t);

--- a/src/source/bcm2835_stream.cpp
+++ b/src/source/bcm2835_stream.cpp
@@ -81,7 +81,9 @@ void Stream::begin(unsigned long baud, int flags)
 	// See: http://unixwiz.net/techtips/termios-vmin-vtime.html
 	options.c_cc[VMIN]  = 0;
 	// Cannot set VTIME to 0 as it creates more problems such as cannot read the driver properly.
-	options.c_cc[VTIME] = 100;       // VTIME defined as tenths of a second so 100 is actually 10 seconds
+    // Also, you do not want to set to 100 because it is a blocking read and timeout in VTIME and can take up to 10 seconds and
+    // if retries are implemented in caller then it feels like something is blocking for N retries x VTIME.
+    options.c_cc[ VTIME ] = 10;      // VTIME defined as tenths of a second so 100 is actually 10 seconds; and 10 deciseconds is 1 second.
 
 	tcflush(fd, TCIOFLUSH); // flush both tx and rx
 	tcsetattr(fd, TCSANOW, &options);
@@ -94,6 +96,28 @@ void Stream::begin(unsigned long baud, int flags)
 void Stream::end()
 {
 	::close(fd);
+}
+
+void Stream::flush( FlushOptions option )
+{
+	switch ( option )
+	{
+		default:
+			printf("[ERROR] UART flush(%s); flushing option: %d\n", m_port, option );
+			break;
+
+		case FlushOptions::Both:
+			tcflush( fd, TCIOFLUSH );
+			break;
+
+		case FlushOptions::Receiver:
+			tcflush( fd, TCIFLUSH );
+			break;
+
+		case FlushOptions::Transmitter:
+			tcflush( fd, TCOFLUSH );
+			break;
+	}
 }
 
 int Stream::available()

--- a/src/source/bcm2835_stream.h
+++ b/src/source/bcm2835_stream.h
@@ -16,10 +16,21 @@ uint32_t millis();
 class Stream
 {
 public:
+	enum FlushOptions
+	{
+		// TCIOFLUSH: flushes both data received but not read, and data written but not transmitted.
+		Both
+		// TCIFLUSH: flushes data received but not read.
+		, Receiver
+		// TCOFLUSH: flushes data written but not transmitted.
+		, Transmitter
+	};
+
 	Stream(const char* port);
 	void begin(unsigned long baud) { begin(baud, O_RDWR | O_NOCTTY | O_NDELAY); }
 	void begin(unsigned long, int);
 	void end();
+	void flush( FlushOptions option );
 	int available(void);
 	uint8_t write(const uint8_t data);
 	uint8_t read();


### PR DESCRIPTION
 * Changed serial port initialisation's VTIME=10 so that if anything goes wrong during serial read from driver, the PiOS will not seem to hang or block for 10s or sometimes 10s to 30s depending on retries. A timeout of 1s is enough. At least comment is there should anyone need to tweak it.
 * Added a more robust way to clear serial buffer if we are using a hardware serial. This is to sort out intermittent blocking or read issues. Do the same for writes as well to avoid general weirdness in serial port.bugs in bcm2835_stream.cpp's begin() to use different baud speed and to resolve general port or driver instability

This is to also resolve some stability issues as mentioned in https://github.com/teemuatlut/TMCStepper/issues/215
