### PR TITLE
Fixed recent issue in making serial port stable caused 10s to 30s blocking call when reading an empty buffer

### DIFF
--- a/src/source/bcm2835_stream.cpp
+++ b/src/source/bcm2835_stream.cpp
@@ -81,7 +81,9 @@ void Stream::begin(unsigned long baud, int flags)
 	// See: http://unixwiz.net/techtips/termios-vmin-vtime.html
 	options.c_cc[VMIN]  = 0;
 	// Cannot set VTIME to 0 as it creates more problems such as cannot read the driver properly.
-	options.c_cc[VTIME] = 100;       // VTIME defined as tenths of a second so 100 is actually 10 seconds
+    // Also, you do not want to set to 100 because it is a blocking read and timeout in VTIME and can take up to 10 seconds and
+    // if retries are implemented in caller then it feels like something is blocking for N retries x VTIME.
+    options.c_cc[ VTIME ] = 10;      // VTIME defined as tenths of a second so 100 is actually 10 seconds; and 10 deciseconds is 1 second.
 
 	tcflush(fd, TCIOFLUSH); // flush both tx and rx
 	tcsetattr(fd, TCSANOW, &options);


### PR DESCRIPTION
* Changed serial port initialisation's VTIME=10 so that if anything goes wrong during serial read from driver, the PiOS will not seem to hang or block for 10s or sometimes 10s to 30s depending on retries. A timeout of 1s is enough. At least comment is there should anyone need to tweak it.



This is a fix to https://github.com/teemuatlut/TMCStepper/issues/215. On flushing, let me think if there is a more general way that can flush nicely and cannot break other code. Obviously, I cannot test them because I do not work on Arduino but will see if there is a general code that can work with AVR, etc. but when there is a HWSerial then hardware flushing occurs.