### PR TITLE
Add TMCSTEPPER_SW_SERIAL to force usage of SW/HW serial

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -14,7 +14,7 @@
 	#include <bcm2835.h>
 	#include "source/bcm2835_spi.h"
 	#include "source/bcm2835_stream.h"
-#elif __cplusplus >= 201703L
+#elif defined(__has_include)
 	#if __has_include(<Arduino.h>)
 		#include <Arduino.h>
 	#endif
@@ -26,13 +26,17 @@
 	#endif
 #endif
 
-#if (__cplusplus == 201703L) && defined(__has_include)
+#ifdef TMCSTEPPER_SW_SERIAL
+	#define SW_CAPABLE_PLATFORM TMCSTEPPER_SW_SERIAL
+#elif defined(__has_include)
 	#define SW_CAPABLE_PLATFORM __has_include(<SoftwareSerial.h>)
 #elif defined(__AVR__) || defined(TARGET_LPC1768) || defined(ARDUINO_ARCH_STM32)
 	#define SW_CAPABLE_PLATFORM true
 #else
 	#define SW_CAPABLE_PLATFORM false
 #endif
+
+#define HAS_HALF_DUPLEX_MODE (SW_CAPABLE_PLATFORM && defined(ARDUINO_ARCH_AVR))
 
 #if SW_CAPABLE_PLATFORM
 	#include <SoftwareSerial.h>
@@ -1006,7 +1010,9 @@ class TMC2208Stepper : public TMCStepper {
 		Stream * HWSerial = nullptr;
 		#if SW_CAPABLE_PLATFORM
 			SoftwareSerial * SWSerial = nullptr;
-			const uint16_t RXTX_pin = 0; // Half duplex
+			#if HAS_HALF_DUPLEX_MODE
+				const uint16_t RXTX_pin = 0; // Set to RX/TX pin when in half-duplex mode, otherwise 0
+			#endif
 		#endif
 
 		SSwitch *sswitch = nullptr;

--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -24,7 +24,9 @@ TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint
 	// addr needed for TMC2209
 	TMC2208Stepper::TMC2208Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, uint8_t addr) :
 		TMCStepper(RS),
-		RXTX_pin(SW_RX_pin == SW_TX_pin ? SW_RX_pin : 0),
+		#if HAS_HALF_DUPLEX_MODE
+			RXTX_pin(SW_RX_pin == SW_TX_pin ? SW_RX_pin : 0),
+		#endif
 		slave_address(addr)
 		{
 			SoftwareSerial *SWSerialObj = new SoftwareSerial(SW_RX_pin, SW_TX_pin);
@@ -38,7 +40,7 @@ TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint
 			SWSerial->begin(baudrate);
 			SWSerial->end();
 		}
-		#if defined(ARDUINO_ARCH_AVR)
+		#if HAS_HALF_DUPLEX_MODE
 			if (RXTX_pin > 0) {
 				digitalWrite(RXTX_pin, HIGH);
 				pinMode(RXTX_pin, OUTPUT);
@@ -204,7 +206,7 @@ void TMC2208Stepper::write(uint8_t addr, uint32_t regVal) {
 uint64_t TMC2208Stepper::_sendDatagram(uint8_t datagram[], const uint8_t len, uint16_t timeout) {
 	while (available() > 0) serial_read(); // Flush
 
-	#if defined(ARDUINO_ARCH_AVR)
+	#if HAS_HALF_DUPLEX_MODE
 		if (RXTX_pin > 0) {
 			digitalWrite(RXTX_pin, HIGH);
 			pinMode(RXTX_pin, OUTPUT);
@@ -213,7 +215,7 @@ uint64_t TMC2208Stepper::_sendDatagram(uint8_t datagram[], const uint8_t len, ui
 
 	for(int i=0; i<=len; i++) serial_write(datagram[i]);
 
-	#if defined(ARDUINO_ARCH_AVR)
+	#if HAS_HALF_DUPLEX_MODE
 		if (RXTX_pin > 0) {
 			pinMode(RXTX_pin, INPUT_PULLUP);
 		}
@@ -266,7 +268,7 @@ uint64_t TMC2208Stepper::_sendDatagram(uint8_t datagram[], const uint8_t len, ui
 		i++;
 	}
 
-	#if defined(ARDUINO_ARCH_AVR)
+	#if HAS_HALF_DUPLEX_MODE
 		if (RXTX_pin > 0) {
 			digitalWrite(RXTX_pin, HIGH);
 			pinMode(RXTX_pin, OUTPUT);


### PR DESCRIPTION
This PR adds a method to force the usage of HW/SW serial, while still maintaining backwards compatibility. This new method can be used together with [small changes](https://github.com/skruppy/Marlin/commit/c53622b1a4f9aa285f70f11759a1cf8bc344d781) to Marlin to _automatically_ select the best method.

**Related issues:**
 * #48 (with the small [Marlin patch](https://github.com/skruppy/Marlin/commit/c53622b1a4f9aa285f70f11759a1cf8bc344d781), your comment gets a solution)
 * #228 (same problem, further down the release pipeline)
 * MarlinFirmware/Marlin#16299 (this was a bug never the less, but it got more visible with my changes, so I had to fix it too)

**Aspects of the PR:**
 * Don't break code / be backwards compatible
 * Changes not tailored specifically for Marlin (don't "detect" the presence of Marlin and behave appropriately)
 * Prevent future name clashes: prefix / scope the new macro with the lib name `TMCSTEPPER_`
 * Allow forcing "HW serial only" mode as well as "SW serial" mode (with a single macro)

If you are planing to release a 0.7.4 with this PR, then I will file the corresponding Marlin PR. If you don't plan to release any further v0 releases, in favor of v1, please add a similar mechanism :smiley: 