### PR TITLE
Fix SPI bus sharing (TFT, SD, Touch, TMC, etc...)

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -63,52 +63,7 @@
 
 #define TMCSTEPPER_VERSION 0x000703 // v0.7.3
 
-// Since we don't have C++20 we need to do some ugly hacks to ensure compat.
-// https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc
-#include <utility>
-#include <type_traits>
-
-#define __DEF_HAS_METH( methName ) \
-	template<typename T> \
-	struct ___has_##methName \
-	{ \
-    template<typename C> \
-    static constexpr auto test(...) -> std::false_type; \
-		template<typename C> \
-		static constexpr auto test(int) \
-		-> decltype(static_cast<void>(std::declval<C>().methName(0)), std::true_type()); \
-    using result_type       = decltype(test<T>(0)); \
-    static const bool value = result_type::value; \
-	}
-#define __HAS_METH( className, methName ) \
-	( ___has_##methName <className>::value )
-
-__DEF_HAS_METH( setMISO );
-__DEF_HAS_METH( setMOSI );
-__DEF_HAS_METH( setSCLK );
-
-#define SPI_SET_PIN_HELPER( pinDescName ) \
-	template <bool hasPin> \
-	struct _spiInitHelper_##pinDescName \
-	{}; \
-	template <> \
-	struct _spiInitHelper_##pinDescName <true> \
-	{ \
-		template <typename SPIClassT> \
-		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{ spi.set##pinDescName( pin ); } \
-	}; \
-	template <> \
-	struct _spiInitHelper_##pinDescName <false> \
-	{ \
-		template <typename SPIClassT> \
-		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{} \
-	}
-
-SPI_SET_PIN_HELPER( MISO );
-SPI_SET_PIN_HELPER( MOSI );
-SPI_SET_PIN_HELPER( SCLK );
-
-#define SPI_INIT_PIN( spi, pinDescName, val ) _spiInitHelper_##pinDescName <__HAS_METH(SPIClass, set##pinDescName)> ::spiSet##pinDescName( spi, val )
+#include "TMCStepper_fixing.h"
 
 class TMCStepper {
 	public:

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -151,11 +151,14 @@ class TMCStepper {
 		float holdMultiplier = 0.5;
 };
 
+#include "TMCStepper_SPI.h"
+
 class TMC2130Stepper : public TMCStepper {
 	public:
 		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2130Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan, int8_t link_index = -1);
 		void begin();
 		void defaults();
 		void setSPISpeed(uint32_t speed);
@@ -370,6 +373,7 @@ class TMC2130Stepper : public TMCStepper {
 		struct DRV_STATUS_t { constexpr static uint8_t address = 0X6F; };
 
 		static uint32_t spi_speed; // Default 2MHz
+		TMCSPIInterface* _spiMan;
 		const uint16_t _pinCS;
 		const uint16_t _pinMISO;
 		const uint16_t _pinMOSI;
@@ -1113,6 +1117,7 @@ class TMC2660Stepper {
 		TMC2660Stepper(uint16_t pinCS, float RS = default_RS);
 		TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = false);
 		TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = false);
+		TMC2660Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan);
 		void write(uint8_t addressByte, uint32_t config);
 		uint32_t read();
 		void switchCSpin(bool state);
@@ -1266,6 +1271,7 @@ class TMC2660Stepper {
 		const uint16_t _pinMOSI;
 		const uint16_t _pinSCK;
 		const bool _has_pins;
+		TMCSPIInterface *_spiMan;
 		const float Rsense;
 		static constexpr float default_RS = 0.1;
 		float holdMultiplier = 0.5;

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -65,6 +65,9 @@
 
 // Since we don't have C++20 we need to do some ugly hacks to ensure compat.
 // https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc
+#include <utility>
+#include <type_traits>
+
 #define __DEF_HAS_METH( methName ) \
 	template<typename T> \
 	struct ___has_##methName \

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -63,6 +63,50 @@
 
 #define TMCSTEPPER_VERSION 0x000703 // v0.7.3
 
+// Since we don't have C++20 we need to do some ugly hacks to ensure compat.
+// https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc
+#define __DEF_HAS_METH( methName ) \
+	template<typename T> \
+	struct ___has_##methName \
+	{ \
+    template<typename C> \
+    static constexpr auto test(...) -> std::false_type; \
+		template<typename C> \
+		static constexpr auto test(int) \
+		-> decltype(static_cast<void>(std::declval<C>().methName(0)), std::true_type()); \
+    using result_type       = decltype(test<T>(0)); \
+    static const bool value = result_type::value; \
+	}
+#define __HAS_METH( className, methName ) \
+	( ___has_##methName <className>::value )
+
+__DEF_HAS_METH( setMISO );
+__DEF_HAS_METH( setMOSI );
+__DEF_HAS_METH( setSCLK );
+
+#define SPI_SET_PIN_HELPER( pinDescName ) \
+	template <bool hasPin> \
+	struct _spiInitHelper_##pinDescName \
+	{}; \
+	template <> \
+	struct _spiInitHelper_##pinDescName <true> \
+	{ \
+		template <typename SPIClassT> \
+		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{ spi.set##pinDescName( pin ); } \
+	}; \
+	template <> \
+	struct _spiInitHelper_##pinDescName <false> \
+	{ \
+		template <typename SPIClassT> \
+		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{} \
+	}
+
+SPI_SET_PIN_HELPER( MISO );
+SPI_SET_PIN_HELPER( MOSI );
+SPI_SET_PIN_HELPER( SCLK );
+
+#define SPI_INIT_PIN( spi, pinDescName, val ) _spiInitHelper_##pinDescName <__HAS_METH(SPIClass, set##pinDescName)> ::spiSet##pinDescName( spi, val )
+
 class TMCStepper {
 	public:
 		uint16_t cs2rms(uint8_t CS);

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -8,7 +8,9 @@
 
 #if defined(ARDUINO) && ARDUINO >= 100
 	#include <Arduino.h>
-	#include <SPI.h>
+	#ifndef TMC_NO_GENERIC_SPI
+		#include <SPI.h>
+	#endif
 	#include <Stream.h>
 #elif defined(bcm2835)
 	#include <bcm2835.h>
@@ -18,8 +20,12 @@
 	#if __has_include(<Arduino.h>)
 		#include <Arduino.h>
 	#endif
-	#if __has_include(<SPI.h>)
-		#include <SPI.h>
+	#ifndef TMC_NO_GENERIC_SPI
+		#if __has_include(<SPI.h>)
+			#include <SPI.h>
+		#else
+			#define TMC_NO_GENERIC_SPI
+		#endif
 	#endif
 	#if __has_include(<Stream.h>)
 		#include <Stream.h>
@@ -153,11 +159,17 @@ class TMCStepper {
 
 #include "TMCStepper_SPI.h"
 
+#ifndef TMC_NO_GENERIC_SPI
+#define _TMC_SOFTSPI_DEFAULT false
+#else
+#define _TMC_SOFTSPI_DEFAULT true
+#endif
+
 class TMC2130Stepper : public TMCStepper {
 	public:
 		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
-		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
 		TMC2130Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan, int8_t link_index = -1);
 		void begin();
 		void defaults();
@@ -373,13 +385,13 @@ class TMC2130Stepper : public TMCStepper {
 		struct DRV_STATUS_t { constexpr static uint8_t address = 0X6F; };
 
 		static uint32_t spi_speed; // Default 2MHz
-		TMCSPIInterface* _spiMan;
 		const uint16_t _pinCS;
 		const uint16_t _pinMISO;
 		const uint16_t _pinMOSI;
 		const uint16_t _pinSCK;
 		const bool _has_pins;
 		SW_SPIClass * TMC_SW_SPI = nullptr;
+		TMCSPIInterface* _spiMan;
 		static constexpr float default_RS = 0.11;
 
 		int8_t link_index;
@@ -389,8 +401,8 @@ class TMC2130Stepper : public TMCStepper {
 class TMC2160Stepper : public TMC2130Stepper {
 	public:
 		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
-		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
 		void begin();
 		void defaults();
 		void push();
@@ -488,8 +500,8 @@ class TMC2160Stepper : public TMC2130Stepper {
 class TMC5130Stepper : public TMC2160Stepper {
 	public:
 		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
-		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
 
 		void begin();
 		void defaults();
@@ -732,8 +744,8 @@ class TMC5130Stepper : public TMC2160Stepper {
 class TMC5160Stepper : public TMC5130Stepper {
 	public:
 		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
-		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
 
 		void rms_current(uint16_t mA) { TMC2160Stepper::rms_current(mA); }
 		void rms_current(uint16_t mA, float mult) { TMC2160Stepper::rms_current(mA, mult); }
@@ -827,9 +839,9 @@ class TMC5161Stepper : public TMC5160Stepper {
 	public:
 		TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) :
 			TMC5160Stepper(pinCS, RS, link_index) {}
-		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false) :
+		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT) :
 			TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK, link_index, softSPI) {}
-		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false) :
+		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT) :
 			TMC5160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link_index, softSPI) {}
 };
 
@@ -1115,8 +1127,8 @@ class TMC2224Stepper : public TMC2208Stepper {
 class TMC2660Stepper {
 	public:
 		TMC2660Stepper(uint16_t pinCS, float RS = default_RS);
-		TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = false);
-		TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = false);
+		TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = _TMC_SOFTSPI_DEFAULT);
 		TMC2660Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan);
 		void write(uint8_t addressByte, uint32_t config);
 		uint32_t read();

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -195,6 +195,7 @@ class TMCStepper {
 
 class TMC2130Stepper : public TMCStepper {
 	public:
+		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		void begin();
@@ -415,6 +416,7 @@ class TMC2130Stepper : public TMCStepper {
 		const uint16_t _pinMISO;
 		const uint16_t _pinMOSI;
 		const uint16_t _pinSCK;
+		const bool _has_pins;
 		SW_SPIClass * TMC_SW_SPI = nullptr;
 		static constexpr float default_RS = 0.11;
 
@@ -424,6 +426,7 @@ class TMC2130Stepper : public TMCStepper {
 
 class TMC2160Stepper : public TMC2130Stepper {
 	public:
+		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		void begin();
@@ -522,6 +525,7 @@ class TMC2160Stepper : public TMC2130Stepper {
 
 class TMC5130Stepper : public TMC2160Stepper {
 	public:
+		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 
@@ -765,6 +769,7 @@ class TMC5130Stepper : public TMC2160Stepper {
 
 class TMC5160Stepper : public TMC5130Stepper {
 	public:
+		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 
@@ -858,6 +863,8 @@ class TMC5160Stepper : public TMC5130Stepper {
 
 class TMC5161Stepper : public TMC5160Stepper {
 	public:
+		TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) :
+			TMC5160Stepper(pinCS, RS, link_index) {}
 		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false) :
 			TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK, link_index, softSPI) {}
 		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false) :
@@ -1145,6 +1152,7 @@ class TMC2224Stepper : public TMC2208Stepper {
 
 class TMC2660Stepper {
 	public:
+		TMC2660Stepper(uint16_t pinCS, float RS = default_RS);
 		TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = false);
 		TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = false);
 		void write(uint8_t addressByte, uint32_t config);
@@ -1299,6 +1307,7 @@ class TMC2660Stepper {
 		const uint16_t _pinMISO;
 		const uint16_t _pinMOSI;
 		const uint16_t _pinSCK;
+		const bool _has_pins;
 		const float Rsense;
 		static constexpr float default_RS = 0.1;
 		float holdMultiplier = 0.5;

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -151,9 +151,8 @@ class TMCStepper {
 
 class TMC2130Stepper : public TMCStepper {
 	public:
-		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
-		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		void begin();
 		void defaults();
 		void setSPISpeed(uint32_t speed);
@@ -369,6 +368,9 @@ class TMC2130Stepper : public TMCStepper {
 
 		static uint32_t spi_speed; // Default 2MHz
 		const uint16_t _pinCS;
+		const uint16_t _pinMISO;
+		const uint16_t _pinMOSI;
+		const uint16_t _pinSCK;
 		SW_SPIClass * TMC_SW_SPI = nullptr;
 		static constexpr float default_RS = 0.11;
 
@@ -378,9 +380,8 @@ class TMC2130Stepper : public TMCStepper {
 
 class TMC2160Stepper : public TMC2130Stepper {
 	public:
-		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
-		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		void begin();
 		void defaults();
 		void push();
@@ -477,9 +478,8 @@ class TMC2160Stepper : public TMC2130Stepper {
 
 class TMC5130Stepper : public TMC2160Stepper {
 	public:
-		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
-		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 
 		void begin();
 		void defaults();
@@ -721,9 +721,8 @@ class TMC5130Stepper : public TMC2160Stepper {
 
 class TMC5160Stepper : public TMC5130Stepper {
 	public:
-		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
-		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 
 		void rms_current(uint16_t mA) { TMC2160Stepper::rms_current(mA); }
 		void rms_current(uint16_t mA, float mult) { TMC2160Stepper::rms_current(mA, mult); }
@@ -815,11 +814,10 @@ class TMC5160Stepper : public TMC5130Stepper {
 
 class TMC5161Stepper : public TMC5160Stepper {
 	public:
-    TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) : TMC5160Stepper(pinCS, RS, link_index) {}
-		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
-			TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK, link_index) {}
-		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
-			TMC5160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link_index) {}
+		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false) :
+			TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK, link_index, softSPI) {}
+		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false) :
+			TMC5160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link_index, softSPI) {}
 };
 
 class TMC2208Stepper : public TMCStepper {
@@ -1103,9 +1101,8 @@ class TMC2224Stepper : public TMC2208Stepper {
 
 class TMC2660Stepper {
 	public:
-		TMC2660Stepper(uint16_t pinCS, float RS = default_RS);
-		TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
-		TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
+		TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = false);
+		TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI = false);
 		void write(uint8_t addressByte, uint32_t config);
 		uint32_t read();
 		void switchCSpin(bool state);
@@ -1255,6 +1252,9 @@ class TMC2660Stepper {
 		INIT_REGISTER(READ_RDSEL10){{.sr=0}};
 
 		const uint16_t _pinCS;
+		const uint16_t _pinMISO;
+		const uint16_t _pinMOSI;
+		const uint16_t _pinSCK;
 		const float Rsense;
 		static constexpr float default_RS = 0.1;
 		float holdMultiplier = 0.5;

--- a/src/TMCStepper_SPI.h
+++ b/src/TMCStepper_SPI.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#define TMCSPI_BITORDER_LSB 0
+#define TMCSPI_BITORDER_MSB 1
+
+#define TMCSPI_CLKMODE_0    0
+#define TMCSPI_CLKMODE_1    1
+#define TMCSPI_CLKMODE_2    2
+#define TMCSPI_CLKMODE_3    3
+
+struct TMCSPIInterface {
+    virtual void begin(uint32_t maxClockFreq, int bitOrder, int clkMode) = 0;
+    virtual void end() = 0;
+    virtual uint8_t transfer(uint8_t txval) = 0;
+    virtual void sendRepeat(uint8_t val, uint16_t repcnt) = 0;
+};

--- a/src/TMCStepper_fixing.h
+++ b/src/TMCStepper_fixing.h
@@ -88,3 +88,16 @@ SPI_SET_PIN_HELPER( MOSI );
 SPI_SET_PIN_HELPER( SCLK );
 
 #define SPI_INIT_PIN( spi, pinDescName, val ) _spiInitHelper_##pinDescName <__HAS_METH(SPIClass, set##pinDescName)> ::spiSet##pinDescName( spi, val )
+
+// Speciality of the ESP32 platform.
+#ifdef ESP_PLATFORM
+// https://github.com/espressif/arduino-esp32/blob/master/libraries/SPI/src/SPI.cpp SPIClass::begin method.
+#define SPI_BEGIN( spi, sck, miso, mosi ) ( spi.begin( sck, miso, mosi ) )
+#else
+// Other platforms.
+#define SPI_BEGIN( spi, sck, miso, mosi ) \
+	{ SPI_INIT_PIN( spi, MISO, miso ); \
+      SPI_INIT_PIN( SPI, MOSI, mosi ); \
+      SPI_INIT_PIN( SPI, SCLK, sck ); \
+	  spi.begin(); }
+#endif

--- a/src/TMCStepper_fixing.h
+++ b/src/TMCStepper_fixing.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifndef TMC_NO_GENERIC_SPI
+
 namespace _TMC_FIXING
 {
 
@@ -101,3 +103,5 @@ SPI_SET_PIN_HELPER( SCLK );
       SPI_INIT_PIN( SPI, SCLK, sck ); \
 	  spi.begin(); }
 #endif
+
+#endif //TMC_NO_GENERIC_SPI

--- a/src/TMCStepper_fixing.h
+++ b/src/TMCStepper_fixing.h
@@ -21,12 +21,16 @@ struct add_rvalue_reference : decltype(detail::try_add_rvalue_reference<T>(0)) {
 
 // END https://en.cppreference.com/w/cpp/types/add_reference
     
-// BEGIN https://en.cppreference.com/w/cpp/utility/declval
-template<typename T> constexpr bool always_false = false;
+// BEGIN https://en.cppreference.com/w/cpp/utility/declval (inspired)
+template<typename T>
+struct always_false
+{
+	enum { value = false };
+};
  
 template<typename T>
-typename add_rvalue_reference<T>::type declval() noexcept {
-    static_assert(always_false<T>, "declval not allowed in an evaluated context");
+typename add_rvalue_reference<T>::type declval() {
+    static_assert(always_false<T>::value, "declval not allowed in an evaluated context");
 }
 
 // END https://en.cppreference.com/w/cpp/utility/declval
@@ -34,9 +38,11 @@ typename add_rvalue_reference<T>::type declval() noexcept {
 struct true_type {
     enum { value = true };
 };
-struct false_type {};
+struct false_type {
     enum { value = false };
 };
+
+} // namespace TMC_FIXING
 
 // Since we don't have C++20 we need to do some ugly hacks to ensure compat.
 // https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc

--- a/src/TMCStepper_fixing.h
+++ b/src/TMCStepper_fixing.h
@@ -1,0 +1,84 @@
+#pragma once
+
+namespace _TMC_FIXING
+{
+
+// BEGIN https://en.cppreference.com/w/cpp/types/add_reference
+namespace detail {
+ 
+template <class T>
+struct type_identity { using type = T; };
+ 
+template <class T>
+auto try_add_rvalue_reference(int) -> type_identity<T&&>;
+template <class T>
+auto try_add_rvalue_reference(...) -> type_identity<T>;
+ 
+} // namespace detail
+ 
+template <class T>
+struct add_rvalue_reference : decltype(detail::try_add_rvalue_reference<T>(0)) {};
+
+// END https://en.cppreference.com/w/cpp/types/add_reference
+    
+// BEGIN https://en.cppreference.com/w/cpp/utility/declval
+template<typename T> constexpr bool always_false = false;
+ 
+template<typename T>
+typename add_rvalue_reference<T>::type declval() noexcept {
+    static_assert(always_false<T>, "declval not allowed in an evaluated context");
+}
+
+// END https://en.cppreference.com/w/cpp/utility/declval
+
+struct true_type {
+    enum { value = true };
+};
+struct false_type {};
+    enum { value = false };
+};
+
+// Since we don't have C++20 we need to do some ugly hacks to ensure compat.
+// https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc
+// Did you know that ATMEL AVR does not support standard C++ headers???
+#define __DEF_HAS_METH( methName ) \
+	template<typename T> \
+	struct ___has_##methName \
+	{ \
+    template<typename C> \
+    static constexpr auto test(...) -> _TMC_FIXING::false_type; \
+		template<typename C> \
+		static constexpr auto test(int) \
+		-> decltype(static_cast<void>(_TMC_FIXING::declval<C>().methName(0)), _TMC_FIXING::true_type()); \
+    using result_type       = decltype(test<T>(0)); \
+    static const bool value = result_type::value; \
+	}
+#define __HAS_METH( className, methName ) \
+	( ___has_##methName <className>::value )
+
+__DEF_HAS_METH( setMISO );
+__DEF_HAS_METH( setMOSI );
+__DEF_HAS_METH( setSCLK );
+
+#define SPI_SET_PIN_HELPER( pinDescName ) \
+	template <bool hasPin> \
+	struct _spiInitHelper_##pinDescName \
+	{}; \
+	template <> \
+	struct _spiInitHelper_##pinDescName <true> \
+	{ \
+		template <typename SPIClassT> \
+		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{ spi.set##pinDescName( pin ); } \
+	}; \
+	template <> \
+	struct _spiInitHelper_##pinDescName <false> \
+	{ \
+		template <typename SPIClassT> \
+		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{} \
+	}
+
+SPI_SET_PIN_HELPER( MISO );
+SPI_SET_PIN_HELPER( MOSI );
+SPI_SET_PIN_HELPER( SCLK );
+
+#define SPI_INIT_PIN( spi, pinDescName, val ) _spiInitHelper_##pinDescName <__HAS_METH(SPIClass, set##pinDescName)> ::spiSet##pinDescName( spi, val )

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -76,9 +76,9 @@ void TMC2130Stepper::switchCSpin(bool state) {
 __attribute__((weak))
 void TMC2130Stepper::beginTransaction() {
   if (TMC_SW_SPI == nullptr) {
-    SPI.setMISO(_pinMISO);
-    SPI.setMOSI(_pinMOSI);
-    SPI.setSCLK(_pinSCK);
+    SPI_INIT_PIN( SPI, MISO, _pinMISO );
+    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
   }

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -4,12 +4,29 @@
 int8_t TMC2130Stepper::chain_length = 0;
 uint32_t TMC2130Stepper::spi_speed = 16000000/8;
 
+TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, int8_t link_index) :
+  TMCStepper(RS),
+  _pinCS(pinCS),
+  _pinMISO(0),
+  _pinMOSI(0),
+  _pinSCK(0),
+  _has_pins(false),
+  link_index(link_index)
+  {
+    TMC_SW_SPI = nullptr;
+    defaults();
+
+    if (link_index > chain_length)
+      chain_length = link_index;
+  }
+
 TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
   TMCStepper(default_RS),
   _pinCS(pinCS),
   _pinMISO(pinMISO),
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
+  _has_pins(true),
   link_index(link)
   {
     if (softSPI)
@@ -33,6 +50,7 @@ TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
   _pinMISO(pinMISO),
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
+  _has_pins(true),
   link_index(link)
   {
     if (softSPI)
@@ -76,9 +94,12 @@ void TMC2130Stepper::switchCSpin(bool state) {
 __attribute__((weak))
 void TMC2130Stepper::beginTransaction() {
   if (TMC_SW_SPI == nullptr) {
-    SPI_INIT_PIN( SPI, MISO, _pinMISO );
-    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    if (_has_pins)
+    {
+      SPI_INIT_PIN( SPI, MISO, _pinMISO );
+      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    }
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
   }

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -96,11 +96,10 @@ void TMC2130Stepper::beginTransaction() {
   if (TMC_SW_SPI == nullptr) {
     if (_has_pins)
     {
-      SPI_INIT_PIN( SPI, MISO, _pinMISO );
-      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+      SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
     }
-    SPI.begin();
+    else
+      SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
   }
 }

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -116,6 +116,7 @@ void TMC2130Stepper::beginTransaction() {
   if (_spiMan) {
     _spiMan->begin(spi_speed, TMCSPI_BITORDER_MSB, TMCSPI_CLKMODE_3);
   }
+#ifndef TMC_NO_GENERIC_SPI
   else if (TMC_SW_SPI == nullptr) {
     if (_has_pins)
     {
@@ -125,16 +126,19 @@ void TMC2130Stepper::beginTransaction() {
       SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
   }
+#endif
 }
 __attribute__((weak))
 void TMC2130Stepper::endTransaction() {
   if (_spiMan) {
     _spiMan->end();
   }
+#ifndef TMC_NO_GENERIC_SPI
   else if (TMC_SW_SPI == nullptr) {
     SPI.endTransaction();
     SPI.end();
   }
+#endif
 }
 
 __attribute__((weak))
@@ -146,9 +150,11 @@ uint8_t TMC2130Stepper::transfer(const uint8_t data) {
   else if (TMC_SW_SPI != nullptr) {
     out = TMC_SW_SPI->transfer(data);
   }
+#ifndef TMC_NO_GENERIC_SPI
   else {
     out = SPI.transfer(data);
   }
+#endif
   return out;
 }
 

--- a/src/source/TMC2160Stepper.cpp
+++ b/src/source/TMC2160Stepper.cpp
@@ -1,13 +1,11 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2130Stepper(pinCS, RS, link)
+TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
-  { defaults(); }
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC2130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link)
+TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC2130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
 
 void TMC2160Stepper::begin() {

--- a/src/source/TMC2160Stepper.cpp
+++ b/src/source/TMC2160Stepper.cpp
@@ -1,6 +1,9 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
+TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, int8_t link_index) :
+  TMC2130Stepper(pinCS, RS, link_index)
+  { defaults(); }
 TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
   TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -1,11 +1,23 @@
 #include "TMCStepper.h"
 #include "SW_SPI.h"
 
+TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS) :
+  _pinCS(pinCS),
+  _pinMISO(0),
+  _pinMOSI(0),
+  _pinSCK(0),
+  _has_pins(false),
+  Rsense(RS)
+  {
+    TMC_SW_SPI = nullptr;
+  }
+
 TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI) :
   _pinCS(pinCS),
   _pinMISO(pinMISO),
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
+  _has_pins(true),
   Rsense(default_RS)
   {
     if (softSPI)
@@ -24,6 +36,7 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
   _pinMISO(pinMISO),
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
+  _has_pins(true),
   Rsense(RS)
   {
     if (softSPI)
@@ -53,9 +66,12 @@ uint32_t TMC2660Stepper::read() {
     response <<= 8;
     response |= TMC_SW_SPI->transfer(dummy & 0xFF);
   } else {
-    SPI_INIT_PIN( SPI, MISO, _pinMISO );
-    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    if (_has_pins)
+    {
+      SPI_INIT_PIN( SPI, MISO, _pinMISO );
+      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    }
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
@@ -79,9 +95,12 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
     TMC_SW_SPI->transfer((data >>  8) & 0xFF);
     TMC_SW_SPI->transfer(data & 0xFF);
   } else {
-    SPI_INIT_PIN( SPI, MISO, _pinMISO );
-    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    if (_has_pins)
+    {
+      SPI_INIT_PIN( SPI, MISO, _pinMISO );
+      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    }
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -92,7 +92,9 @@ uint32_t TMC2660Stepper::read() {
     response |= TMC_SW_SPI->transfer((dummy >>  8) & 0xFF);
     response <<= 8;
     response |= TMC_SW_SPI->transfer(dummy & 0xFF);
-  } else {
+  }
+#ifndef TMC_NO_GENERIC_SPI
+  else {
     if (_has_pins)
     {
       SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
@@ -109,6 +111,7 @@ uint32_t TMC2660Stepper::read() {
     SPI.endTransaction();
     SPI.end();
   }
+#endif
   switchCSpin(HIGH);
   return response >> 4;
 }
@@ -128,7 +131,9 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
     TMC_SW_SPI->transfer((data >> 16) & 0xFF);
     TMC_SW_SPI->transfer((data >>  8) & 0xFF);
     TMC_SW_SPI->transfer(data & 0xFF);
-  } else {
+  }
+#ifndef TMC_NO_GENERIC_SPI
+  else {
     if (_has_pins)
     {
       SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
@@ -143,6 +148,7 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
     SPI.endTransaction();
     SPI.end();
   }
+#endif
   switchCSpin(HIGH);
 }
 

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -53,9 +53,9 @@ uint32_t TMC2660Stepper::read() {
     response <<= 8;
     response |= TMC_SW_SPI->transfer(dummy & 0xFF);
   } else {
-    SPI.setMISO(_pinMISO);
-    SPI.setMOSI(_pinMOSI);
-    SPI.setSCLK(_pinSCK);
+    SPI_INIT_PIN( SPI, MISO, _pinMISO );
+    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
@@ -79,9 +79,9 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
     TMC_SW_SPI->transfer((data >>  8) & 0xFF);
     TMC_SW_SPI->transfer(data & 0xFF);
   } else {
-    SPI.setMISO(_pinMISO);
-    SPI.setMOSI(_pinMOSI);
-    SPI.setSCLK(_pinSCK);
+    SPI_INIT_PIN( SPI, MISO, _pinMISO );
+    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -68,11 +68,10 @@ uint32_t TMC2660Stepper::read() {
   } else {
     if (_has_pins)
     {
-      SPI_INIT_PIN( SPI, MISO, _pinMISO );
-      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+      SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
     }
-    SPI.begin();
+    else
+      SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
     response |= SPI.transfer((dummy >> 16) & 0xFF);
@@ -97,11 +96,10 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
   } else {
     if (_has_pins)
     {
-      SPI_INIT_PIN( SPI, MISO, _pinMISO );
-      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+      SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
     }
-    SPI.begin();
+    else
+      SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
     SPI.transfer((data >> 16) & 0xFF);

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -7,9 +7,11 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS) :
   _pinMOSI(0),
   _pinSCK(0),
   _has_pins(false),
-  Rsense(RS)
+  _spiMan(nullptr),
+  Rsense(RS),
+  TMC_SW_SPI(nullptr)
   {
-    TMC_SW_SPI = nullptr;
+    return;
   }
 
 TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI) :
@@ -18,6 +20,7 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMIS
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
   _has_pins(true),
+  _spiMan(nullptr),
   Rsense(default_RS)
   {
     if (softSPI)
@@ -37,6 +40,7 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
   _has_pins(true),
+  _spiMan(nullptr),
   Rsense(RS)
   {
     if (softSPI)
@@ -50,6 +54,19 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
     }
   }
 
+TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan) :
+  _pinCS(pinCS),
+  _pinMISO(0),
+  _pinMOSI(0),
+  _pinSCK(0),
+  _has_pins(false),
+  _spiMan(spiMan),
+  Rsense(RS),
+  TMC_SW_SPI(nullptr)
+  {
+    return;
+  }
+
 void TMC2660Stepper::switchCSpin(bool state) {
   // Allows for overriding in child class to make use of fast io
   digitalWrite(_pinCS, state);
@@ -58,7 +75,17 @@ void TMC2660Stepper::switchCSpin(bool state) {
 uint32_t TMC2660Stepper::read() {
   uint32_t response = 0UL;
   uint32_t dummy = ((uint32_t)DRVCONF_register.address<<17) | DRVCONF_register.sr;
-  if (TMC_SW_SPI != nullptr) {
+  if (_spiMan) {
+    _spiMan->begin(spi_speed, TMCSPI_BITORDER_MSB, TMCSPI_CLKMODE_3);
+    switchCSpin(LOW);
+    response |= _spiMan->transfer((dummy >> 16) & 0xFF);
+    response <<= 8;
+    response |= _spiMan->transfer((dummy >>  8) & 0xFF);
+    response <<= 8;
+    response |= _spiMan->transfer(dummy & 0xFF);
+    _spiMan->end();
+  }
+  else if (TMC_SW_SPI != nullptr) {
     switchCSpin(LOW);
     response |= TMC_SW_SPI->transfer((dummy >> 16) & 0xFF);
     response <<= 8;
@@ -88,7 +115,15 @@ uint32_t TMC2660Stepper::read() {
 
 void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
   uint32_t data = (uint32_t)addressByte<<17 | config;
-  if (TMC_SW_SPI != nullptr) {
+  if (_spiMan) {
+    _spiMan->begin(spi_speed, TMCSPI_BITORDER_MSB, TMCSPI_CLKMODE_3);
+    switchCSpin(LOW);
+    _spiMan->transfer((data >> 16) & 0xFF);
+    _spiMan->transfer((data >>  8) & 0xFF);
+    _spiMan->transfer(data & 0xFF);
+    _spiMan->end();
+  }
+  else if (TMC_SW_SPI != nullptr) {
     switchCSpin(LOW);
     TMC_SW_SPI->transfer((data >> 16) & 0xFF);
     TMC_SW_SPI->transfer((data >>  8) & 0xFF);

--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -1,13 +1,11 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2160Stepper(pinCS, RS, link)
+TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI):
+  TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link):
-  TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
-  { defaults(); }
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC2160Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link)
+TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC2160Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
 
 void TMC5130Stepper::begin() {

--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -1,6 +1,9 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
+TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, int8_t link_index) :
+  TMC2160Stepper(pinCS, RS, link_index)
+  { defaults(); }
 TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI):
   TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }

--- a/src/source/TMC5160Stepper.cpp
+++ b/src/source/TMC5160Stepper.cpp
@@ -1,13 +1,11 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC5130Stepper(pinCS, RS, link)
+TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
-  { defaults(); }
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC5130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link)
+TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC5130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
 
 void TMC5160Stepper::defaults() {

--- a/src/source/TMC5160Stepper.cpp
+++ b/src/source/TMC5160Stepper.cpp
@@ -1,6 +1,9 @@
 #include "TMCStepper.h"
 #include "TMC_MACROS.h"
 
+TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, int8_t link_index) :
+  TMC5130Stepper(pinCS, RS, link_index)
+  { defaults(); }
 TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
   TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }


### PR DESCRIPTION
- fixed SPI bus sharing between TFT, SD, Touch, etc in combination with TMC by properly initializing and then terminating the SPI usage

in the way that this library was previously written it was not easy to share the SPI bus between components because the SPI protocol was not properly terminated/cleaned-up across SPI sessions, causing conflicts for different SPI bus components. This library has been tested with Marlin 2.1.x bugfix on this repo: github.com/quiret/Marlin/

There is a Marlin pull request that would really appreciate this improvement: https://github.com/MarlinFirmware/Marlin/pull/24911

Please consider releasing another version of this library with the included fix onto platformio so that the Marlin FW can be really improved! clobbering the global SPI object is not a good idea, especially on single-SPI boards...

Martin Turski, company owner of EirDev (turningtides@outlook.de)