### PR TITLE
add callback function to TMC2208/TMC2209

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -840,6 +840,7 @@ class TMC2208Stepper : public TMCStepper {
 		#else
 			TMC2208Stepper(uint16_t, uint16_t, float) = delete; // Your platform does not currently support Software Serial
 		#endif
+		TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, void (*cb)(uint32_t, uint32_t), uint32_t cb_vala, uint32_t cb_valb);
 		void defaults();
 		void push();
 		void begin();
@@ -1010,6 +1011,8 @@ class TMC2208Stepper : public TMCStepper {
 		#endif
 
 		SSwitch *sswitch = nullptr;
+		void (*cb_func)(uint32_t, uint32_t) = nullptr;  // callback function
+		uint32_t cb_val0, cb_val1;  // callback values
 
 		int available();
 		void preWriteCommunication();
@@ -1042,6 +1045,8 @@ class TMC2209Stepper : public TMC2208Stepper {
 		#else
 			TMC2209Stepper(uint16_t, uint16_t, float, uint8_t) = delete; // Your platform does not currently support Software Serial
 		#endif
+		TMC2209Stepper(Stream * SerialPort, float RS, uint8_t addr, void (*cb)(uint32_t, uint32_t), uint32_t cb_vala, uint32_t cb_valb) :
+			TMC2208Stepper(SerialPort, RS, addr, cb, cb_vala, cb_valb) {}
 		void push();
 
 		// R: IOIN

--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -19,6 +19,14 @@ TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint
 		sswitch = SMulObj;
 	}
 
+TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, void (*cb)(uint32_t, uint32_t), uint32_t cb_vala, uint32_t cb_valb) :
+	TMC2208Stepper(SerialPort, RS, addr)
+	{
+		cb_func = cb;
+		cb_val0 = cb_vala;
+		cb_val1 = cb_valb;
+	}
+
 #if SW_CAPABLE_PLATFORM
 	// Protected
 	// addr needed for TMC2209
@@ -126,6 +134,8 @@ void TMC2208Stepper::preWriteCommunication() {
 	if (HWSerial != nullptr) {
 		if (sswitch != nullptr)
 			sswitch->active();
+		if (cb_func != nullptr)
+			(*cb_func)(cb_val0, cb_val1);
 	}
 }
 
@@ -139,6 +149,8 @@ void TMC2208Stepper::preReadCommunication() {
 		if (HWSerial != nullptr) {
 			if (sswitch != nullptr)
 				sswitch->active();
+			if (cb_func != nullptr)
+				(*cb_func)(cb_val0, cb_val1);
 		}
 }
 


### PR DESCRIPTION
I had a problem using TMCStepper from Marlin where Marlin controls a multiplexer to route the serial line to the appropriate stepper.  This is similar in spirit to the SSwitch multiplexing that is used by TMC2208Stepper, except that the pins are not Arduino pins, but are extended pins available only to Marlin.  (Specifically, it uses the I2S output of the ESP32 and shift register to generate several more output pins.)

To achieve the appropriate multiplexer switching in preReadCommunication and preWriteCommunication, I have added a callback function.  Ordinarily the callback function is null and has no effect, but if a callback function and callback parameters are passed to the constructor, then it invokes the function during preReadCommunication and preWriteCommunication.

The parameters `cb_vala` and `cb_valb` are opaque to TMCStepper, but the callback function unpacks the values to know which pins and what values need to be assigned to the multiplexer pins.

---
What are your thoughts on whether this can be merged into the TMCStepper library?  Eventually I am hoping the Marlin code that uses the callback can also be merged into the Marlin code, but for that to work, this would be a prerequisite.