### PR TITLE
Resolved issues with ESP-IDF 5.3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(SRC_DIRS src/source
                        INCLUDE_DIRS "src"
+                       PRIV_REQUIRES driver
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wfatal-errors)

--- a/src/source/TMC_HAL.h
+++ b/src/source/TMC_HAL.h
@@ -301,7 +301,7 @@
     #include <driver/gpio.h>
     #include <driver/spi_master.h>
     #include <driver/uart.h>
-    #include <esp32/clk.h>
+    #include <esp_private/esp_clk.h>
     #include <hal/cpu_ll.h>
 
     #define SW_CAPABLE_PLATFORM false
@@ -323,7 +323,7 @@
     using HardwareSerial = uart_port_t;
 
     inline void delay(const uint16_t ms) {
-        ets_delay_us( ms * 1000 );
+        vTaskDelay(ms / portTICK_PERIOD_MS);
     }
 
     namespace TMC_HAL {


### PR DESCRIPTION
Added a requirement for the `driver` component and fixes `esp32/clk.h` being removed from the public API. This solves compilation issues with ESP-IDF 5.3 (likely from 5.0 already).